### PR TITLE
fix(redact): REDACTJS_PATH was wrong → share uploaded UNREDACTED HTML

### DIFF
--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -14,7 +14,12 @@ const { execSync } = require("child_process");
 const CONFIG_DIR = path.dirname(__dirname);
 const CONFIG_FILE = path.join(CONFIG_DIR, "CONFIG.md");
 const TRASH_DIR = path.join(CONFIG_DIR, "trash");
-const REDACTJS_PATH = path.join(CONFIG_DIR, "redact.js");
+// redact.js lives next to this file (scripts/), NOT at CONFIG_DIR root.
+// The previous CONFIG_DIR-based path silently no-op'd redact() on every call
+// (existsSync returned false → early return), so `share` was uploading raw
+// HTML with zero redaction applied. countRedactRules() already used a
+// 2-candidate fallback that included this path; redact() never did.
+const REDACTJS_PATH = path.join(__dirname, "redact.js");
 const API_BASE = "https://api.mapick.ai/api/v1";
 // Detect the skills install directory: openclaw / claude / codex live in different paths per platform.
 // Priority: env override -> ~/.openclaw -> ~/.claude -> ~/.codex; falls back to .openclaw if none exist.


### PR DESCRIPTION
Closes #13.

## What broke

`scripts/shell.js:17` resolved `REDACTJS_PATH` to `<repo>/redact.js`, but the actual file ships at `scripts/redact.js`. `fs.existsSync(REDACTJS_PATH)` was always `false`, so `redact()` early-returned the input unchanged. The only outbound caller — `share` — then uploaded user-generated HTML to `/share/upload` with **zero redaction applied**.

## Why this is P0

This directly contradicts the README's headline privacy promise: *"every byte leaving your machine gets redacted first"*. A user generating a persona-share HTML that embeds an email / SSH key / phone number ships it to `api.mapick.ai` verbatim.

Before this PR:
```
$ node -e "const fs=require('fs'); console.log(fs.existsSync(require('path').dirname(require.resolve('./scripts/shell.js')) + '/../redact.js'));"
false
```

After this PR:
```
$ node -e "...with __dirname-based path..."
true
$ echo 'sk-ant-X1234567890ABCDEFGHIJKLMNOP' | node scripts/redact.js
[REDACTED]
```

## Fix

Single-line change: anchor `REDACTJS_PATH` to `__dirname/redact.js` (scripts/), the canonical location. `countRedactRules()` already used `__dirname/redact.js` as one of its 2-candidate fallback paths — so the summary card correctly reported "23 rules active" while `redact()` itself was a silent no-op. This patch makes `redact()` resolve consistently with `countRedactRules()`.

## Verification

```bash
$ env -u NODE_OPTIONS node -e "
const path = require('path');
const REDACTJS_PATH = path.join(process.cwd(), 'scripts', 'redact.js');
const out = require('child_process').execSync('node ' + REDACTJS_PATH, {
  input: 'my key is sk-ant-X1234567890ABCDEFGHIJKLMNOP',
  encoding: 'utf8',
});
console.log(out.trim());
"
my key is [REDACTED]
```

## Source

Discovered while reviewing comments on #10 (the privacy-tradeoffs discussion). Owner spotted the path mismatch during triage; this fixes the **correctness** bug independently of the design discussions in #10.