### PR TITLE
fix(httpCall): pass backend body through on 401/404/429 instead of fixed shapes

### DIFF
--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -186,19 +186,24 @@ async function httpCall(method, endpoint, body = null) {
             error: "network_error",
             message: err ? err.message : "no_status_code",
           });
-        } else if (code === 401) {
-          resolve({ error: "unauthorized", statusCode: 401 });
-        } else if (code === 404) {
-          resolve({ error: "not_found", statusCode: 404 });
-        } else if (code === 429) {
-          resolve({ error: "rate_limit", statusCode: 429 });
         } else if (code >= 400) {
-          // Try to surface backend-shaped error JSON; fall back to raw body.
+          // Pass through backend body for ALL 4xx/5xx, including 401/404/429.
+          // Previously these three had fixed shapes that dropped the backend's
+          // `message` / `hint` / `retryAfterSec` / etc. — so the AI saw a bare
+          // "unauthorized" with no way to tell the user to run consent-agree
+          // (regression of mapickii PR-21).
+          const stableErrors = {
+            401: "unauthorized",
+            404: "not_found",
+            429: "rate_limit",
+          };
+          const errCode = stableErrors[code] || "http_error";
           try {
             const parsed = JSON.parse(data);
-            resolve({ error: "http_error", statusCode: code, ...parsed });
+            // backend body merged into result; statusCode authoritative.
+            resolve({ error: errCode, statusCode: code, ...parsed });
           } catch {
-            resolve({ error: "http_error", statusCode: code, body: data });
+            resolve({ error: errCode, statusCode: code, body: data });
           }
         } else {
           try {


### PR DESCRIPTION
Closes #7.

## What broke

`httpCall` had three special-case branches for 401 / 404 / 429 that resolved with a hard-coded `{ error, statusCode }` object and discarded the parsed backend body. The fall-through `>=400` branch already does the right thing (`...parsed` spread), but those three branches bypassed it.

Concrete impact: when the backend returns a structured 401 like

```json
{"error":"unauthorized","message":"x-device-fp header OR api-key/api-secret required","statusCode":401}
```

the resolved object the AI receives is

```json
{"error":"unauthorized","statusCode":401}
```

The `message` and any `hint` / `retryAfterSec` are dropped. The AI then can't tell the user *what to do* — run `consent-agree`, wait for rate limit reset, etc.

## Why this is a regression

mapickii's `_http()` (bash port) had the same class of bug and fixed it in PR-21:

> 旧行为：所有非 2xx 都覆盖成 service_unreachable，吞掉了 backend 的 `{"error":"consent_required",...}` ... 导致 AI 看到的永远是 E_API_DOWN，无法引导用户走 consent-agree。

The Node port reintroduced the same problem for 401/404/429 specifically.

## Fix

Collapse the three special cases into the existing `>=400` branch. 401/404/429 still get stable `error` codes (`unauthorized` / `not_found` / `rate_limit`) for downstream matching, but the parsed body is merged in so all backend fields are preserved.

```js
const stableErrors = { 401: "unauthorized", 404: "not_found", 429: "rate_limit" };
const errCode = stableErrors[code] || "http_error";
try {
  const parsed = JSON.parse(data);
  resolve({ error: errCode, statusCode: code, ...parsed });
} catch {
  resolve({ error: errCode, statusCode: code, body: data });
}
```

## Acceptance (per #7)

- [x] When backend returns 401 with body `{message: "..."}`, the resolved object includes `message`.
- [x] Same for 429 with `{retryAfterSec}`.
- [x] No regression on 200 / 5xx / network_error paths.