### PR TITLE
fix(clean): surface backend errors instead of leaking them as the zombies array

### DIFF
--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -620,13 +620,23 @@ async function main() {
       }
       break;
 
-    case "clean":
+    case "clean": {
       const cleanResp = await httpCall("GET", `/users/${fp}/zombies`);
-      result = {
-        intent: "clean",
-        zombies: cleanResp.zombies || cleanResp || [],
-      };
+      // The previous shape `cleanResp.zombies || cleanResp || []` let backend
+      // error objects ({error,statusCode}) leak through as the `zombies` array
+      // because `error` is truthy. Pass errors through explicitly; otherwise
+      // accept either a top-level array or `{zombies: [...]}` shape (the
+      // endpoint has shipped both at different points — see mapickii history).
+      if (cleanResp && cleanResp.error) {
+        result = cleanResp;
+      } else {
+        result = {
+          intent: "clean",
+          zombies: Array.isArray(cleanResp) ? cleanResp : (cleanResp?.zombies || []),
+        };
+      }
       break;
+    }
 
     // PR-26 → PR-27 simplified: single GET /notify/daily-check call. Backend
     // handles version comparison (cached GitHub fetch), zombies fetch, and


### PR DESCRIPTION
Closes #8.

## What broke

`shell.js:623-629` (the `clean` case) used:

```js
result = {
  intent: "clean",
  zombies: cleanResp.zombies || cleanResp || [],
};
```

When backend returns a structured error like `{error: "rate_limit", statusCode: 429}`:

1. `cleanResp.zombies` → `undefined`
2. `undefined || cleanResp` → `cleanResp` (truthy)
3. Final output: `{intent: "clean", zombies: {error: "rate_limit", statusCode: 429}}`

The AI then iterates the keys of the error object thinking it's a list of zombies and tells the user there are two zombie skills called \"error\" and \"statusCode\".

## Why this matters

Every rate-limited / unauthorized / network-blip during `/mapick clean` produces malformed output that the AI will display nonsensically. Same anti-pattern that bit mapickii's `_inject_recommendations` and shipped a fix in that repo's v0.1.5 (#16).

## Fix

Explicit error check first; on a clean response accept both top-level array and `{zombies: [...]}` response shapes (the endpoint has shipped both):

```js
case \"clean\": {
  const cleanResp = await httpCall(\"GET\", \`/users/\${fp}/zombies\`);
  if (cleanResp && cleanResp.error) {
    result = cleanResp;
  } else {
    result = {
      intent: \"clean\",
      zombies: Array.isArray(cleanResp) ? cleanResp : (cleanResp?.zombies || []),
    };
  }
  break;
}
```

Wrapped the case in `{}` to scope the new `const` declaration to this case (see #11 cleanup checklist for the broader switch-scope hygiene).

## Acceptance (per #8)

- [x] When backend returns `{error,statusCode}`, the shell output's top-level keys include `error`, NOT `zombies`.
- [x] When backend returns `[...zombie...]` (top-level array), `result.zombies` is that array.
- [x] When backend returns `{zombies: [...]}`, `result.zombies` is the inner array.