### PR TITLE
fix(event:track): always use local fp; drop userId from CLI signature

### DIFF
--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -969,26 +969,33 @@ async function main() {
       break;
 
     case "event":
-    case "event:track":
-      if (ARGS.length < 2) {
+    case "event:track": {
+      // Always use the local fp; never accept userId from CLI args. The
+      // sibling track commands (recommend:track / clean:track / profile-text)
+      // already work this way. Letting userId flow in from ARGS was a
+      // misleading API surface — the help text actively asked the AI to
+      // supply a userId — and a future-footgun if the backend ever stops
+      // cross-checking the x-device-fp header against body.userId.
+      if (ARGS.length < 1) {
         result = {
           error: "missing_argument",
-          hint: "Usage: event:track <userId> <action> [skillId]",
+          hint: "Usage: event:track <action> [skillId]",
         };
         break;
       }
-      const [userId, actionType, metaSkillId] = ARGS;
+      const [actionType, metaSkillId] = ARGS;
       if (!VALID_EVENT_ACTIONS.includes(actionType)) {
         result = { error: "invalid_action", valid: VALID_EVENT_ACTIONS };
         break;
       }
       result = await httpCall("POST", "/events/track", {
-        userId,
+        userId: fp,
         action: actionType,
         skillId: metaSkillId || null,
       });
       result.intent = "event:track";
       break;
+    }
 
     // First-install diagnostic card aggregation: local skills + (optional) backend top_used / security counts.
     case "summary": {
@@ -1107,7 +1114,7 @@ Commands:
   privacy delete-all --confirm  GDPR erasure
   privacy consent-agree [version]  Record consent
   privacy consent-decline      Decline consent (local-only mode)
-  event:track <userId> <action> [skillId]  Record event
+  event:track <action> [skillId]  Record event (always uses local device fp)
   summary                 First-run diagnostic (local + optional backend)
   profile set "<text>"    Save user workflow self-description
   profile get             Read cached workflow profile


### PR DESCRIPTION
Closes #9.

## What broke

`event:track` was the only track-style command in `scripts/shell.js` that read `userId` from CLI args and forwarded it verbatim. Sibling commands all use `userId: fp` unconditionally:

| Command | Source of `userId` in POST body |
| --- | --- |
| `recommend:track` (line ~588) | `fp` |
| `clean:track` (line ~666) | `fp` |
| `profile set` (line ~1024) | path-encoded fp |
| **`event:track` (line 980)** | **`ARGS[0]` ← from caller** |

This made the help text actively ask the AI to *supply* a userId (`Usage: event:track <userId> <action> [skillId]`), which is misleading at best and a future-footgun if the backend ever stops cross-checking `body.userId` against the `x-device-fp` header.

## Why P1, not P0

Owner downgrade noted in the issue: today `httpCall` always sends `x-device-fp: ${deviceFp()}` so this isn't actively exploitable. The footgun is in the API surface, not in current behavior.

## Fix

- Take only `<action> [skillId]` from ARGS.
- Always set `userId: fp` in the POST body.
- Update the help text.
- Wrap the case in `{}` to scope the new `const` declarations (also addresses the case-scope item in #11 for this specific case).

## Acceptance (per #9)

- [x] `event:track` no longer accepts `userId` as a CLI arg.
- [x] Backend POST body always uses the local fp from `deviceFp()`.
- [x] Help text updated.
- [ ] Backend-side guard verification (out of scope for this PR — log here if backend cross-check needs to be confirmed).