### PR TITLE
feat(updates): detect-only update + notify-setup with AI delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CONFIG.md
+trash/

--- a/CLAWHUB.md
+++ b/CLAWHUB.md
@@ -80,6 +80,14 @@ Three opt-outs, one command each:
 - **Skill uninstall** is two-step: `clean` only lists; `uninstall <id>`
   requires `--confirm`, refuses protected Skills (mapick / tasa), backs
   up to `trash/` first, auto-cleans backups older than 7 days.
+- **Updates are detect-only** — Mapick checks for new versions of itself
+  and your installed Skills, but **never installs, upgrades, removes, or
+  modifies other Skills unless you explicitly confirm**. Every install /
+  upgrade action surfaces a plan first (commands + what-it-does +
+  what-it-doesn't + how-to-stop), and the AI runs it via its bash tool
+  only after you reply "confirm". Mapick itself has zero subprocess
+  execution. Disable detection entirely with
+  `node scripts/shell.js update:settings off`.
 
 ## Requirements
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -258,11 +258,16 @@ For `upgrade:plan <id>` to work, `<id>` should be `mapick` or any installed Skil
 
 When shell returns `{intent: "*:plan", commands, what_it_does, what_it_doesnt, stops}`:
 
+Each entry in `commands[]` has a `kind` field (default `"command"` if absent):
+- `kind: "command"` — render the literal `command` string in the plan box.
+- `kind: "instruction"` — render the `instruction` text as a paraphrase prefixed with "AI step:".
+
 ```
 I'll run:
 
-  $ <commands[0].command>
-  $ <commands[1].command>
+  $ <commands[0].command>           ← if kind: "command"
+  AI step: <commands[1].instruction>  ← if kind: "instruction"
+  $ <commands[2].command>
 
 What it does: <what_it_does>
 What it doesn't: <what_it_doesnt>
@@ -276,9 +281,10 @@ NEVER auto-confirm. NEVER omit the `what_it_doesnt` line.
 ### After user confirms
 
 1. For each step in `commands`:
-   - If `executes_in_mapick: true` → run via `node scripts/shell.js <subcommand>`.
-   - Otherwise → run via your bash tool (e.g. `openclaw skills install mapick`).
-   - Capture exit code + last 200 chars of stderr.
+   - `kind: "command"` AND `executes_in_mapick: true` → run via `node scripts/shell.js <subcommand>`.
+   - `kind: "command"` (default) → run the literal `command` via your bash tool.
+   - `kind: "instruction"` → execute the multi-step instruction in `instruction` text. Typically this means: run a list/inspect command, parse its output, then run zero-or-more derived commands. Capture each derived command's outcome.
+   - Capture exit code + last 200 chars of stderr per command.
 2. On any failure: stop. If `after_failure_rollback`, run it. Tell user the exact failure (translate stderr).
 3. On full success: run `after_success_track`. Reply with one-line confirmation.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -206,6 +206,96 @@ Templates: `reference/rendering.md#notify-silence-first`.
 
 ---
 
+## 10. Updates & Notify Setup
+
+### Intent: check / set up reminders / upgrade
+Triggers: any update?, what's outdated, check updates, set up daily reminders, notify me when updates, 帮我装 notify, 升级 mapick, 把可升级的都升级, 关闭更新提醒.
+
+Mapick **detects** but **never** auto-installs/auto-upgrades. All install / upgrade / cron-setup actions return a `*:plan` JSON for the AI to render and ask the user "确认 / cancel?" before running. The AI runs the actual command via its bash tool — Mapick itself has zero subprocess execution.
+
+### Detect
+
+Command: `node scripts/shell.js update:check`
+
+Returns `{intent: "update:check", items: [...]}`. Each item is one update opportunity:
+- `mapick_self` — Mapick has a newer version
+- `skill` — an installed Skill has a newer version (requires `/skills/check-updates` backend; fails silently if unavailable)
+- `notify_missing` — daily-notify cron not running (heuristic: `last_notify_at` empty or > 7 days old)
+
+`settings.update_mode: "off"` returns empty items + an explainer message. Same when `consent_declined`.
+
+### Render `update:check`
+
+If `items: []` and no `message`: reply "Everything's up to date." If `items: []` with `message`: render the message verbatim. Otherwise:
+
+```
+Found <N> things:
+
+- Mapick v0.0.15 → v0.0.17. "upgrade mapick"
+- github-ops v1.2.0 → v1.3.0. "upgrade github-ops"
+- Daily reminders not set up. "set up daily reminders"
+
+Reply with what you want, or "skip" / "暂时不要".
+```
+
+NEVER show raw JSON. NEVER auto-execute.
+
+### Natural-language authorization
+
+Match user reply to `items[].next.trigger_phrases` OR semantic equivalent (any language). On match, run the item's `next.command` (which returns a `*:plan`).
+
+| User says | Run |
+| --- | --- |
+| "upgrade mapick" / "升级 mapick" | `node scripts/shell.js upgrade:plan mapick` |
+| "upgrade <skillId>" | `node scripts/shell.js upgrade:plan <skillId>` |
+| "set up daily reminders" / "开通知" | `node scripts/shell.js notify:plan` |
+| "install all" / "全装" | run each item's `next.command` in turn |
+| "skip" / "暂时不要" | run `node scripts/shell.js update:dismissed <id>` for each item, reply "ok" |
+
+For `upgrade:plan <id>` to work, `<id>` should be `mapick` or any installed Skill ID.
+
+### Render `*:plan`
+
+When shell returns `{intent: "*:plan", commands, what_it_does, what_it_doesnt, stops}`:
+
+```
+I'll run:
+
+  $ <commands[0].command>
+  $ <commands[1].command>
+
+What it does: <what_it_does>
+What it doesn't: <what_it_doesnt>
+To stop later: <stops>
+
+Confirm? Reply "确认" / "yes" to proceed, or "取消" to abort.
+```
+
+NEVER auto-confirm. NEVER omit the `what_it_doesnt` line.
+
+### After user confirms
+
+1. For each step in `commands`:
+   - If `executes_in_mapick: true` → run via `node scripts/shell.js <subcommand>`.
+   - Otherwise → run via your bash tool (e.g. `openclaw skills install mapick`).
+   - Capture exit code + last 200 chars of stderr.
+2. On any failure: stop. If `after_failure_rollback`, run it. Tell user the exact failure (translate stderr).
+3. On full success: run `after_success_track`. Reply with one-line confirmation.
+
+### Settings
+
+- `node scripts/shell.js update:settings off` — disable detection entirely.
+- `node scripts/shell.js update:settings on` — default. Detect + tell user when there are items.
+- `node scripts/shell.js notify:status` — show last notify activity + dismissal expiry.
+
+Dismissal:
+- `update:dismissed notify_setup` — silent on cron-setup prompt for **14 days**.
+- `update:dismissed <skillId> [version]` — silent on that skill upgrade for **7 days**.
+
+Mapick **does not install, upgrade, remove, or modify other Skills unless you explicitly confirm the action.** All install/upgrade actions show a plan before execution; rollback is supported via `backup:restore`.
+
+---
+
 ## Auto-trigger / First-run
 
 On new Mapick session, run `node scripts/shell.js init` (idempotent, 30-min cooldown). Detail: `reference/lifecycle.md#auto-trigger-on-new-conversation`.

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,22 @@
 
 All notable changes to Mapick will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `update:check` command detects updates for Mapick self + installed Skills + missing daily-notify cron (heuristic: `last_notify_at` empty or > 7 days old).
+- `notify:plan` / `notify:disable` / `notify:status` / `notify:track` — return cron setup/teardown plans for the AI to execute. Mapick code performs zero subprocess.
+- `upgrade:plan <id>` — returns install plan for `mapick` or any installed Skill. Skill upgrades include a Mapick-side `backup:create` step before the AI runs `openclaw skills install`.
+- `update:settings off|on` — disable / enable detection.
+- `update:dismissed <id> [version]` — silence prompts for 14 days (notify_setup) or 7 days (per skill version).
+- `update:track` — AI reports install/upgrade outcome, Mapick logs to `~/.mapick/logs/install.jsonl`.
+- `backup:create` / `backup:restore` — explicit backup commands (reuse existing `trash/` mechanism).
+- `/skills/check-updates` added to outbound endpoint allowlist (best-effort: backend may not have implemented yet — fails silent).
+- SKILL.md §10 documents the full flow: detect → plan → user confirms → AI runs → Mapick verifies.
+- `/mapick notify` now writes `last_notify_at` so update:check can detect stale cron.
+- CLAWHUB.md adds the "updates are detect-only, never silent install" trust statement.
+
 ## v0.0.15 - 2026-04-29
 
 ### Changed

--- a/scripts/lib/clean.js
+++ b/scripts/lib/clean.js
@@ -7,6 +7,8 @@ const {
   isoNow, isProtected,
 } = require("./core");
 const { httpCall, apiCall, missingArg } = require("./http");
+// path / SKILLS_BASE / TRASH_DIR / isoNow are used by the new backup:create
+// and backup:restore handlers below as well as the original clean handlers.
 
 function backupSkill(skillPath) {
   if (!fs.existsSync(TRASH_DIR)) fs.mkdirSync(TRASH_DIR, { recursive: true });
@@ -83,9 +85,60 @@ function handleUninstall(args) {
   };
 }
 
+// `backup:create <id>` — copy ~/.openclaw/skills/<id> into trash/ for restore.
+// Used as Mapick-side step 1 of upgrade:plan so an upgrade can be rolled back.
+function handleBackupCreate(args) {
+  if (args.length < 1) return missingArg("Usage: backup:create <skillId>");
+  const id = args[0];
+  const skillDir = path.join(SKILLS_BASE, id);
+  if (!fs.existsSync(skillDir)) {
+    return { error: "not_found", skillId: id };
+  }
+  const backup = backupSkill(skillDir);
+  return {
+    intent: "backup:create",
+    skillId: id,
+    backup_path: backup,
+    backed_up_at: isoNow(),
+  };
+}
+
+// `backup:restore <id>` — pull the most recent backup of <id> back from trash/.
+function handleBackupRestore(args) {
+  if (args.length < 1) return missingArg("Usage: backup:restore <skillId>");
+  const id = args[0];
+  if (!fs.existsSync(TRASH_DIR)) {
+    return { error: "no_backup_found", skillId: id };
+  }
+  const matches = fs
+    .readdirSync(TRASH_DIR)
+    .filter((name) => name.startsWith(`${id}_`))
+    .map((name) => ({
+      name,
+      path: path.join(TRASH_DIR, name),
+      mtime: fs.statSync(path.join(TRASH_DIR, name)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+  if (matches.length === 0) {
+    return { error: "no_backup_found", skillId: id };
+  }
+  const latest = matches[0];
+  const skillDir = path.join(SKILLS_BASE, id);
+  fs.rmSync(skillDir, { recursive: true, force: true });
+  fs.cpSync(latest.path, skillDir, { recursive: true });
+  return {
+    intent: "backup:restore",
+    skillId: id,
+    restored_from: latest.path,
+    restored_at: isoNow(),
+  };
+}
+
 module.exports = {
   backupSkill,
   handleClean,
   handleTrack,
   handleUninstall,
+  handleBackupCreate,
+  handleBackupRestore,
 };

--- a/scripts/lib/core.js
+++ b/scripts/lib/core.js
@@ -168,6 +168,32 @@ function isConsentDeclined(config) {
   return config.consent_declined === "true";
 }
 
+// Resolve installed Mapick version. OpenClaw 安装时会把版本写到
+// `<install-dir>/.version`，但开发模式（直接从 git clone 跑）没有该文件，
+// 此时 fallback 到 VERSION.md 的最新非 Unreleased 章节标题。
+//
+// 之前 misc.js / updates.js 都自己 readFileSync(.version)，没有 fallback，
+// 导致 dev clone 下 /mapick notify 与 update:check 永远不报 mapick_self
+// 更新。集中到这里一次性解决。
+function readInstalledVersion() {
+  const versionFile = path.join(CONFIG_DIR, ".version");
+  try {
+    const v = fs.readFileSync(versionFile, "utf8").trim();
+    if (v) return v;
+  } catch {}
+  // Fallback：解析 VERSION.md 第一个 `## vX.Y.Z` 标题（跳过 `## Unreleased`）。
+  // VERSION.md 与 CONFIG_DIR 同级，是项目里唯一权威的版本时间线。
+  const versionMd = path.join(CONFIG_DIR, "VERSION.md");
+  try {
+    const lines = fs.readFileSync(versionMd, "utf8").split("\n");
+    for (const line of lines) {
+      const m = line.match(/^##\s+(v\d+\.\d+\.\d+(?:-[\w.]+)?)\b/);
+      if (m) return m[1];
+    }
+  } catch {}
+  return null;
+}
+
 function redactForUpload(text) {
   if (!text) return { ok: false, error: "empty_upload" };
   const config = readConfig();
@@ -189,5 +215,5 @@ module.exports = {
   VALID_TRACK_ACTIONS, VALID_EVENT_ACTIONS, PROTECTED_SKILLS, REMOTE_COMMANDS,
   stableHash16, isoNow, clampOutput, parseFrontmatter, extractProfileTags,
   readConfig, writeConfig, deleteConfig, readCache, writeCache, deviceFp,
-  isProtected, isConsentDeclined, redactForUpload,
+  isProtected, isConsentDeclined, redactForUpload, readInstalledVersion,
 };

--- a/scripts/lib/http.js
+++ b/scripts/lib/http.js
@@ -56,6 +56,7 @@ const ALLOWED_ENDPOINTS = [
   /^\/assistant\/(status|workflow|daily-digest|weekly)\/[a-f0-9]{16}$/,
   /^\/recommendations\/(feed|track)$/,
   /^\/skills\/live-search$/,
+  /^\/skills\/check-updates$/,
   /^\/users\/[a-f0-9]{16}\/(zombies|profile-text)$/,
   /^\/users\/(trusted-skills|data|consent)$/,
   /^\/events\/track$/,

--- a/scripts/lib/misc.js
+++ b/scripts/lib/misc.js
@@ -61,6 +61,9 @@ async function handleNotify() {
       return !(alert.latest && baseVersion === String(alert.latest).split("-")[0]);
     });
   }
+  // Track liveness — used by `update:check` to detect stale notify and prompt
+  // the user to (re)set up the cron.
+  writeConfig("last_notify_at", isoNow());
   return { intent: "notify", ...resp };
 }
 

--- a/scripts/lib/misc.js
+++ b/scripts/lib/misc.js
@@ -7,7 +7,7 @@ const {
   CONFIG_DIR, OUT_ARR, VALID_EVENT_ACTIONS,
   isoNow, extractProfileTags, redactForUpload,
   writeConfig, deleteConfig,
-  isConsentDeclined,
+  isConsentDeclined, readInstalledVersion,
 } = require("./core");
 const { httpCall, apiCall, missingArg } = require("./http");
 
@@ -40,11 +40,7 @@ async function handleWeekly(_args, ctx) {
 
 // Single GET /notify/daily-check; backend handles version cmp + zombies + activity bump.
 async function handleNotify() {
-  const versionFile = path.join(CONFIG_DIR, ".version");
-  let installedVer = "";
-  try {
-    installedVer = fs.readFileSync(versionFile, "utf8").trim();
-  } catch {}
+  const installedVer = readInstalledVersion() || "";
   // Backend has a per-repo allowlist; without `repo` it returns alerts: [].
   const params = new URLSearchParams();
   if (installedVer) params.set("currentVersion", installedVer);
@@ -246,11 +242,7 @@ function handleFirstRunDone() {
 }
 
 function handleDiagnose() {
-  const versionFile = path.join(CONFIG_DIR, ".version");
-  let version = null;
-  try {
-    version = fs.readFileSync(versionFile, "utf8").trim();
-  } catch {}
+  const version = readInstalledVersion();
 
   const home = process.env.HOME || "";
   const workspaceDuplicate = path.join(

--- a/scripts/lib/updates.js
+++ b/scripts/lib/updates.js
@@ -1,0 +1,423 @@
+// Update detection + plan rendering. All commands are zero-subprocess —
+// Mapick only DETECTS and RETURNS plans. Actual install/upgrade is run
+// by the AI via its bash tool after explicit user confirmation.
+//
+// See SKILL.md §10 for the full flow.
+
+const fs = require("fs");
+const path = require("path");
+const {
+  CONFIG_DIR, OUT_ARR, SKILLS_BASE,
+  isoNow, parseFrontmatter,
+  readConfig, writeConfig, deleteConfig,
+  isConsentDeclined,
+} = require("./core");
+const { httpCall, missingArg } = require("./http");
+
+const NOTIFY_STALE_DAYS = 7;            // notify hasn't run for 7 days → stale
+const NOTIFY_DISMISSED_DAYS = 14;       // user said "later" → silent for 14 days
+const SKILL_DISMISSED_DAYS = 7;         // single-skill dismissal → 7 days
+const VALID_UPDATE_MODES = new Set(["off", "on"]);
+
+// Default mode = "on": detect + tell user. "off" disables detection entirely.
+function getUpdateMode(config) {
+  const m = config.update_mode || "on";
+  return VALID_UPDATE_MODES.has(m) ? m : "on";
+}
+
+// Compares two ISO strings; returns elapsed days (or Infinity if either is missing).
+function daysSince(iso) {
+  if (!iso) return Infinity;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return Infinity;
+  return (Date.now() - t) / 86_400_000;
+}
+
+// `update_dismissed` in CONFIG.md is a comma-separated list of
+// `<id>:<version>:<iso>` tuples. Returns Map<"id:version", iso>.
+function parseDismissed(config) {
+  const raw = config.update_dismissed || "";
+  const map = new Map();
+  for (const entry of raw.split(",").filter(Boolean)) {
+    const lastColon = entry.lastIndexOf(":");
+    const secondLast = entry.lastIndexOf(":", lastColon - 1);
+    if (lastColon < 0 || secondLast < 0) continue;
+    const id = entry.slice(0, secondLast);
+    const version = entry.slice(secondLast + 1, lastColon);
+    const iso = entry.slice(lastColon + 1);
+    map.set(`${id}:${version}`, iso);
+  }
+  return map;
+}
+
+function serializeDismissed(map) {
+  const out = [];
+  for (const [key, iso] of map) {
+    out.push(`${key}:${iso}`);
+  }
+  return out.join(",");
+}
+
+function isDismissedActive(map, id, version) {
+  const iso = map.get(`${id}:${version}`);
+  if (!iso) return false;
+  return daysSince(iso) < SKILL_DISMISSED_DAYS;
+}
+
+function readInstalledVersion() {
+  const versionFile = path.join(CONFIG_DIR, ".version");
+  try {
+    return fs.readFileSync(versionFile, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function scanInstalledSkills() {
+  const out = [];
+  if (!fs.existsSync(SKILLS_BASE)) return out;
+  for (const dir of fs.readdirSync(SKILLS_BASE)) {
+    const skillFile = path.join(SKILLS_BASE, dir, "SKILL.md");
+    if (!fs.existsSync(skillFile)) continue;
+    try {
+      const fm = parseFrontmatter(fs.readFileSync(skillFile, "utf8"));
+      out.push({
+        id: dir,
+        name: typeof fm.name === "string" && fm.name ? fm.name : dir,
+        version: typeof fm.version === "string" ? fm.version : null,
+      });
+    } catch {}
+  }
+  return out;
+}
+
+// `update:check` — detect 4 categories, return items[] for AI to render.
+async function handleCheck(_args, ctx) {
+  const config = readConfig();
+  const mode = getUpdateMode(config);
+  if (mode === "off") {
+    return {
+      intent: "update:check",
+      checked_at: isoNow(),
+      settings: { update_mode: "off" },
+      items: [],
+      message: "Update detection disabled. Run `node scripts/shell.js update:settings on` to re-enable.",
+    };
+  }
+  if (isConsentDeclined(config)) {
+    return {
+      intent: "update:check",
+      checked_at: isoNow(),
+      settings: { update_mode: mode },
+      items: [],
+      message: "Remote checks disabled (you opted out). Run `node scripts/shell.js privacy consent-agree` to resume.",
+    };
+  }
+
+  const items = [];
+  const dismissed = parseDismissed(config);
+
+  // 1. Mapick self version.
+  const installedVer = readInstalledVersion();
+  if (installedVer) {
+    const params = new URLSearchParams({
+      currentVersion: installedVer,
+      repo: "mapick-ai/mapick",
+      compact: "1",
+      limit: String(OUT_ARR),
+    });
+    const resp = await httpCall("GET", `/notify/daily-check?${params}`);
+    if (!resp.error && Array.isArray(resp.alerts)) {
+      const baseVersion = installedVer.split("-")[0];
+      for (const alert of resp.alerts) {
+        if (alert?.type !== "version") continue;
+        if (alert.latest && baseVersion === String(alert.latest).split("-")[0]) continue;
+        if (isDismissedActive(dismissed, "mapick", alert.latest)) continue;
+        items.push({
+          type: "mapick_self",
+          current: alert.current || installedVer,
+          latest: alert.latest,
+          severity: "info",
+          summary: `Mapick ${alert.current || installedVer} → ${alert.latest}.`,
+          next: {
+            command: "node scripts/shell.js upgrade:plan mapick",
+            trigger_phrases: ["upgrade mapick", "升级 mapick", "update mapick"],
+          },
+        });
+      }
+    }
+  }
+
+  // 2. notify_missing — heuristic from last_notify_at + dismissal.
+  const lastNotify = config.last_notify_at;
+  const notifyStale = daysSince(lastNotify) > NOTIFY_STALE_DAYS;
+  const notifyDismissedActive =
+    daysSince(config.notify_setup_dismissed_at) < NOTIFY_DISMISSED_DAYS;
+  if (notifyStale && !notifyDismissedActive) {
+    items.push({
+      type: "notify_missing",
+      reason: lastNotify ? "stale_last_run" : "never_run",
+      last_run_at: lastNotify || null,
+      severity: "info",
+      summary: lastNotify
+        ? `Daily reminders may not be running (last check: ${Math.round(daysSince(lastNotify))} days ago).`
+        : "Daily reminders not set up — Mapick won't ping you proactively.",
+      next: {
+        command: "node scripts/shell.js notify:plan",
+        trigger_phrases: ["set up daily reminders", "开通知", "帮我装 notify", "set up notify"],
+      },
+    });
+  }
+
+  // 3. Installed skill updates (best-effort; backend endpoint may not exist yet).
+  const skills = scanInstalledSkills();
+  if (skills.length > 0) {
+    const payload = {
+      skills: skills.map((s) => ({ id: s.id, version: s.version })),
+    };
+    const resp = await httpCall("POST", "/skills/check-updates", payload);
+    if (!resp.error && Array.isArray(resp.results)) {
+      for (const r of resp.results) {
+        if (!r.hasUpdate) continue;
+        if (isDismissedActive(dismissed, r.id, r.latestVersion)) continue;
+        const skill = skills.find((s) => s.id === r.id);
+        items.push({
+          type: "skill",
+          id: r.id,
+          name: skill?.name || r.id,
+          current: r.currentVersion,
+          latest: r.latestVersion,
+          severity: r.severity || "info",
+          summary: `${skill?.name || r.id} ${r.currentVersion} → ${r.latestVersion}.`,
+          next: {
+            command: `node scripts/shell.js upgrade:plan ${r.id}`,
+            trigger_phrases: [`upgrade ${r.id}`, `升级 ${r.id}`],
+          },
+        });
+      }
+    }
+    // Endpoint not deployed yet → resp.error is "not_found" or similar; skip silently.
+  }
+
+  return {
+    intent: "update:check",
+    checked_at: isoNow(),
+    settings: { update_mode: mode },
+    items,
+  };
+}
+
+// `notify:plan` — return the cron-registration plan for AI to execute.
+function handleNotifyPlan() {
+  return {
+    intent: "notify_setup:plan",
+    target: "mapick-notify",
+    purpose: "Daily 9am check for version updates + zombie skills",
+    commands: [
+      {
+        step: 1,
+        command: "openclaw cron rm mapick-notify",
+        optional: true,
+        rationale: "Remove any existing entry first (idempotent; ignore exit code)",
+      },
+      {
+        step: 2,
+        command:
+          'openclaw cron add --name mapick-notify --cron "0 9 * * *" --session isolated --message "Run /mapick notify" --best-effort-deliver --timeout-seconds 120',
+        optional: false,
+        rationale: "Schedule the daily check",
+      },
+    ],
+    what_it_does:
+      "Each day at 9am OpenClaw fires the message 'Run /mapick notify'. Your agent sees that, calls /mapick notify, which queries api.mapick.ai/notify/daily-check for any version alerts or zombie warnings.",
+    what_it_doesnt:
+      "No data leaves your machine on registration. The cron only schedules a future trigger; it does not itself send anything.",
+    stops:
+      "Run `openclaw cron rm mapick-notify` any time. Or run `node scripts/shell.js notify:disable` to get this same command back.",
+    after_success_track: "node scripts/shell.js notify:track setup_complete",
+    after_failure_rollback: null,
+  };
+}
+
+// `notify:disable` — symmetrical to notify:plan; returns the rm-only plan.
+function handleNotifyDisable() {
+  return {
+    intent: "notify_disable:plan",
+    target: "mapick-notify",
+    commands: [
+      {
+        step: 1,
+        command: "openclaw cron rm mapick-notify",
+        optional: false,
+        rationale: "Remove the daily-notify cron",
+      },
+    ],
+    what_it_does:
+      "Stops Mapick from receiving the 9am daily message. /mapick notify still works manually.",
+    what_it_doesnt:
+      "Does not remove any data, history, or settings — only the schedule.",
+    stops: "Run `node scripts/shell.js notify:plan` to set it up again later.",
+    after_success_track: "node scripts/shell.js notify:track disable_complete",
+    after_failure_rollback: null,
+  };
+}
+
+// `upgrade:plan <id>` — return install plan for mapick or any installed skill.
+function handleUpgradePlan(args) {
+  const target = args[0];
+  if (!target) return missingArg("Usage: upgrade:plan <id>  (id = `mapick` or any installed skill id)");
+
+  if (target === "mapick") {
+    return {
+      intent: "upgrade:plan",
+      target: { type: "mapick_self", id: "mapick" },
+      commands: [
+        {
+          step: 1,
+          command: "openclaw skills install mapick",
+          optional: false,
+          rationale: "Replace current install with the latest published version",
+        },
+      ],
+      what_it_does:
+        "Fetches the latest Mapick from ClawHub and replaces your current install. Your CONFIG.md (consent state, dismissals, profile) is preserved by the installer.",
+      what_it_doesnt:
+        "Does not touch other Skills. Does not modify ~/.openclaw/ outside ~/.openclaw/skills/mapick/.",
+      stops:
+        "Cancel before running. After the install you can `git checkout` an older version inside the install dir if needed.",
+      after_success_track: "node scripts/shell.js update:track mapick latest success",
+      after_failure_rollback: null,
+    };
+  }
+
+  // Skill upgrade — Mapick handles the backup step itself; OpenClaw does the install.
+  return {
+    intent: "upgrade:plan",
+    target: { type: "skill", id: target },
+    commands: [
+      {
+        step: 1,
+        command: `node scripts/shell.js backup:create ${target}`,
+        optional: false,
+        rationale: "Mapick copies the current install into ~/.openclaw/skills/mapick/trash/",
+        executes_in_mapick: true,
+      },
+      {
+        step: 2,
+        command: `openclaw skills install ${target}`,
+        optional: false,
+        rationale: "OpenClaw fetches and installs the latest version",
+      },
+    ],
+    what_it_does: `Backs up the current ${target}/ directory, then runs \`openclaw skills install ${target}\` which fetches the latest version.`,
+    what_it_doesnt:
+      "Mapick does not call openclaw on its own; you (or your agent) run the install command. Other Skills are not touched.",
+    stops:
+      "Cancel before step 2 — backup is harmless on its own. Restore with `node scripts/shell.js backup:restore <id>` if step 2 went wrong.",
+    after_success_track: `node scripts/shell.js update:track ${target} latest success`,
+    after_failure_rollback: `node scripts/shell.js backup:restore ${target}`,
+  };
+}
+
+// `update:track <id> <version> <result>` — AI reports the outcome.
+function handleUpdateTrack(args) {
+  if (args.length < 3) return missingArg("Usage: update:track <id> <version> <success|fail>");
+  const [id, version, result] = args;
+  appendInstallLog({
+    ts: isoNow(),
+    kind: "upgrade",
+    id,
+    version,
+    result,
+  });
+  if (id === "mapick" && result === "success") {
+    // Mapick replaced itself; nothing more to do — next launch picks up the new code.
+  }
+  return { intent: "update:track", id, version, result, recorded: true };
+}
+
+// `notify:track <result>` — AI reports cron registration result.
+function handleNotifyTrack(args) {
+  const result = args[0] || "unknown";
+  appendInstallLog({
+    ts: isoNow(),
+    kind: "notify_setup",
+    result,
+  });
+  if (result === "setup_complete") {
+    // Reset stale flag — cron is fresh.
+    writeConfig("last_notify_at", isoNow());
+    deleteConfig("notify_setup_dismissed_at");
+  } else if (result === "disable_complete") {
+    deleteConfig("last_notify_at");
+  }
+  return { intent: "notify:track", result, recorded: true };
+}
+
+// `update:settings <off|on>`
+function handleSettings(args) {
+  const mode = (args[0] || "").toLowerCase();
+  if (!VALID_UPDATE_MODES.has(mode)) {
+    return missingArg(`Usage: update:settings <${[...VALID_UPDATE_MODES].join("|")}>`);
+  }
+  writeConfig("update_mode", mode);
+  return { intent: "update:settings", update_mode: mode };
+}
+
+// `update:dismissed <id> [version]` — drop one or more items into dismissal list.
+// Pass `notify_setup` as id to dismiss the cron-setup prompt for 14 days.
+function handleDismissed(args) {
+  if (args.length < 1) return missingArg("Usage: update:dismissed <id> [version]");
+  const id = args[0];
+  if (id === "notify_setup") {
+    writeConfig("notify_setup_dismissed_at", isoNow());
+    return { intent: "update:dismissed", id: "notify_setup", days: NOTIFY_DISMISSED_DAYS };
+  }
+  const version = args[1] || "any";
+  const config = readConfig();
+  const map = parseDismissed(config);
+  map.set(`${id}:${version}`, isoNow());
+  writeConfig("update_dismissed", serializeDismissed(map));
+  return { intent: "update:dismissed", id, version, days: SKILL_DISMISSED_DAYS };
+}
+
+// `notify:status` — read last_notify_at + report cron health inference.
+function handleNotifyStatus() {
+  const config = readConfig();
+  const lastNotify = config.last_notify_at;
+  return {
+    intent: "notify:status",
+    last_notify_at: lastNotify || null,
+    days_since_last: lastNotify ? Math.round(daysSince(lastNotify) * 10) / 10 : null,
+    looks_active: lastNotify && daysSince(lastNotify) <= NOTIFY_STALE_DAYS,
+    setup_dismissed_until: config.notify_setup_dismissed_at
+      ? new Date(
+          new Date(config.notify_setup_dismissed_at).getTime() +
+            NOTIFY_DISMISSED_DAYS * 86_400_000,
+        ).toISOString()
+      : null,
+  };
+}
+
+// Append-only log of install/upgrade actions, mirrors outbound.jsonl.
+function appendInstallLog(entry) {
+  try {
+    const os = require("os");
+    const logDir = path.join(os.homedir(), ".mapick", "logs");
+    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+    const logFile = path.join(logDir, "install.jsonl");
+    fs.appendFileSync(logFile, JSON.stringify(entry) + "\n");
+  } catch {}
+}
+
+module.exports = {
+  handleCheck,
+  handleNotifyPlan,
+  handleNotifyDisable,
+  handleUpgradePlan,
+  handleUpdateTrack,
+  handleNotifyTrack,
+  handleSettings,
+  handleDismissed,
+  handleNotifyStatus,
+};

--- a/scripts/lib/updates.js
+++ b/scripts/lib/updates.js
@@ -7,10 +7,10 @@
 const fs = require("fs");
 const path = require("path");
 const {
-  CONFIG_DIR, OUT_ARR, SKILLS_BASE,
+  CONFIG_DIR, OUT_ARR, SKILLS_BASE, PROTECTED_SKILLS,
   isoNow, parseFrontmatter,
   readConfig, writeConfig, deleteConfig,
-  isConsentDeclined,
+  isConsentDeclined, readInstalledVersion,
 } = require("./core");
 const { httpCall, missingArg } = require("./http");
 
@@ -64,19 +64,14 @@ function isDismissedActive(map, id, version) {
   return daysSince(iso) < SKILL_DISMISSED_DAYS;
 }
 
-function readInstalledVersion() {
-  const versionFile = path.join(CONFIG_DIR, ".version");
-  try {
-    return fs.readFileSync(versionFile, "utf8").trim();
-  } catch {
-    return null;
-  }
-}
-
+// 扫描 ~/.openclaw/skills/* 用于 /skills/check-updates 批查询。
+// 跳过 PROTECTED_SKILLS（mapick / tasa 自身）—— mapick 走 mapick_self
+// 检测，没有理由再放进 skill 类别让后端落 missing[]。
 function scanInstalledSkills() {
   const out = [];
   if (!fs.existsSync(SKILLS_BASE)) return out;
   for (const dir of fs.readdirSync(SKILLS_BASE)) {
+    if (PROTECTED_SKILLS.includes(dir.toLowerCase())) continue;
     const skillFile = path.join(SKILLS_BASE, dir, "SKILL.md");
     if (!fs.existsSync(skillFile)) continue;
     try {
@@ -207,6 +202,19 @@ async function handleCheck(_args, ctx) {
   };
 }
 
+// Reusable: instruction step that tells the AI to list+by-id-rm any
+// pre-existing mapick-notify cron entries. `openclaw cron rm <name>`
+// silently no-ops (returns ok:true, removed:false) — only by-ID removal
+// actually works. Without this step, every plan run accumulates a new
+// duplicate entry.
+const RM_BY_ID_INSTRUCTION = {
+  kind: "instruction",
+  instruction:
+    "Run `openclaw cron list --json`. Parse the JSON. For EACH entry whose `name` is `mapick-notify`, run `openclaw cron rm <id>` (using the entry's `id` field). This MUST be by ID — `openclaw cron rm mapick-notify` (by name) silently no-ops. If there are no matching entries, do nothing and continue.",
+  rationale:
+    "Idempotent: removes any pre-existing mapick-notify entries before adding a fresh one, so re-running the plan does not accumulate duplicates.",
+};
+
 // `notify:plan` — return the cron-registration plan for AI to execute.
 function handleNotifyPlan() {
   return {
@@ -214,14 +222,10 @@ function handleNotifyPlan() {
     target: "mapick-notify",
     purpose: "Daily 9am check for version updates + zombie skills",
     commands: [
-      {
-        step: 1,
-        command: "openclaw cron rm mapick-notify",
-        optional: true,
-        rationale: "Remove any existing entry first (idempotent; ignore exit code)",
-      },
+      { step: 1, optional: true, ...RM_BY_ID_INSTRUCTION },
       {
         step: 2,
+        kind: "command",
         command:
           'openclaw cron add --name mapick-notify --cron "0 9 * * *" --session isolated --message "Run /mapick notify" --best-effort-deliver --timeout-seconds 120',
         optional: false,
@@ -233,7 +237,7 @@ function handleNotifyPlan() {
     what_it_doesnt:
       "No data leaves your machine on registration. The cron only schedules a future trigger; it does not itself send anything.",
     stops:
-      "Run `openclaw cron rm mapick-notify` any time. Or run `node scripts/shell.js notify:disable` to get this same command back.",
+      "Run `node scripts/shell.js notify:disable` to get the by-id removal plan.",
     after_success_track: "node scripts/shell.js notify:track setup_complete",
     after_failure_rollback: null,
   };
@@ -245,12 +249,7 @@ function handleNotifyDisable() {
     intent: "notify_disable:plan",
     target: "mapick-notify",
     commands: [
-      {
-        step: 1,
-        command: "openclaw cron rm mapick-notify",
-        optional: false,
-        rationale: "Remove the daily-notify cron",
-      },
+      { step: 1, optional: false, ...RM_BY_ID_INSTRUCTION },
     ],
     what_it_does:
       "Stops Mapick from receiving the 9am daily message. /mapick notify still works manually.",

--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -30,6 +30,7 @@ const recommend = require("./lib/recommend");
 const clean = require("./lib/clean");
 const security = require("./lib/security");
 const misc = require("./lib/misc");
+const updates = require("./lib/updates");
 
 const HANDLERS = {
   init: skills.handleInit,
@@ -44,11 +45,23 @@ const HANDLERS = {
   clean: clean.handleClean,
   "clean:track": clean.handleTrack,
   uninstall: clean.handleUninstall,
+  "backup:create": clean.handleBackupCreate,
+  "backup:restore": clean.handleBackupRestore,
 
   security: security.handleSecurity,
   "security:report": security.handleReport,
 
   privacy: privacy.handle,
+
+  "update:check": updates.handleCheck,
+  "update:settings": updates.handleSettings,
+  "update:dismissed": updates.handleDismissed,
+  "update:track": updates.handleUpdateTrack,
+  "upgrade:plan": updates.handleUpgradePlan,
+  "notify:plan": updates.handleNotifyPlan,
+  "notify:disable": updates.handleNotifyDisable,
+  "notify:track": updates.handleNotifyTrack,
+  "notify:status": updates.handleNotifyStatus,
 
   workflow: misc.handleWorkflow,
   daily: misc.handleDaily,


### PR DESCRIPTION
## Summary

Mapick now detects updates for itself, installed Skills, and the daily-notify cron — but never auto-installs anything. All install / upgrade / cron-setup actions return a `*:plan` JSON describing the commands; the AI runs them via its bash tool only after the user explicitly confirms ("确认" / "yes"). Mapick code stays at zero subprocess execution.

This addresses the ClawHub `security/openclaw` review's "autonomous execution" concern while restoring functionality that was disabled in v0.0.13's scan-safe build (auto-cron registration).

## What changed

### Three detection categories

- `mapick_self` — uses existing `/notify/daily-check` (already on the manifest)
- `skill` — POSTs to `/skills/check-updates` (new backend endpoint, mapick-api issue #22 — deployed)
- `notify_missing` — heuristic from `last_notify_at`. `/mapick notify` now writes this timestamp on every successful run, so update:check can tell when the daily cron isn't firing.

### 12 new commands (zero subprocess)

| Command | Purpose |
| --- | --- |
| `update:check` | Detect, return items with trigger phrases for AI |
| `notify:plan` / `notify:disable` | Cron setup/teardown plans |
| `upgrade:plan <id>` | mapick or any installed Skill; skill upgrades include a Mapick-side `backup:create` step |
| `update:track` / `notify:track` | AI reports outcomes; Mapick logs to `~/.mapick/logs/install.jsonl` |
| `update:settings off\|on` | User toggle (default: on) |
| `update:dismissed <id> [version]` | Silence prompts (notify_setup: 14 days; per-skill version: 7 days) |
| `notify:status` | Read `last_notify_at` + dismissal expiry |
| `backup:create` / `backup:restore` | Explicit backup commands (reuse existing `trash/` + 7-day TTL) |

### CONFIG.md schema additions

```
update_mode: on                              # off | on
last_notify_at: <ISO>                        # written by /mapick notify on success
notify_setup_dismissed_at: <ISO>             # 14-day silent window
update_dismissed: <id>:<version>:<ISO>,...   # per-skill version dismissals
```

### Allowlist + manifest

- `/skills/check-updates` added to `lib/http.js` `ALLOWED_ENDPOINTS`
- Outbound manifest comment updated implicitly (already documents POST endpoints by-pattern)

### Docs

- **SKILL.md §10** — full flow + render templates ("I'll run / What it does / What it doesn't / To stop later" plan box) + "no install without explicit confirm" rule
- **CLAWHUB.md** — adds trust-signal bullet: *"Updates are detect-only; Mapick does not install/upgrade/remove other Skills unless you explicitly confirm"*
- **VERSION.md Unreleased** — enumerates the new commands

## Why AI delegation (not subprocess)

v0.0.13 removed all `child_process` from Mapick to eliminate ClawHub's `Dangerous Code Execution` CRITICAL flag. Re-introducing `spawn("openclaw", ...)` for upgrade flows would re-trigger that flag.

Instead: Mapick returns plans as **data** (JSON strings); the AI runs the actual commands via its own bash tool after explicit user confirmation. Same pattern we already use for recommend → install (SKILL.md §1).

Effect: zero subprocess in Mapick code, ClawHub static scan stays clean, user has explicit consent at every step.

## Verification

End-to-end smoke tests on the deployed `/skills/check-updates`:

- [x] All 11 .js files syntax-check
- [x] `update:check` returns proper structure (mapick_self, notify_missing, skill items)
- [x] `update:settings off` → empty items + explainer message
- [x] `update:settings <bogus>` → missing_argument
- [x] `update:dismissed notify_setup` → 14-day silent window verified (set + expire)
- [x] `update:dismissed <id> <ver>` → 7-day per-skill window
- [x] `notify:plan` / `upgrade:plan mapick` / `upgrade:plan <skillId>` schemas match spec
- [x] `backup:create` + `backup:restore` round-trip (write → "broken upgrade" → restore → original content)
- [x] `update:track` / `notify:track` write `~/.mapick/logs/install.jsonl`
- [x] `consent_declined` blocks `update:check` with informative message (not a hard error)
- [x] `/mapick notify` updates `last_notify_at` on success only (not on backend error — by design)
- [x] `/skills/check-updates` is in allowlist; `/admin/secret` is not
- [x] Empty skills array → 400 from backend
- [x] Unknown skill ID → goes to `missing[]`, not `results[]`
- [x] Outbound log records every call (POST /skills/check-updates entry confirmed)
- [x] Zero `child_process` / `execSync` / `spawn` in `scripts/lib/*.js` (allowlist confirms)

## Backend dependency

- **mapick-api issue #22** (`POST /skills/check-updates` batch endpoint) — deployed. Mapick falls through silently if the endpoint returns 4xx/5xx/network error, so this PR can ship even if the endpoint is rolled back.

## Known minor

- Backend strips `v` prefix from input version (`v1.0.0` → `1.0.0` in `latestVersion`). Mapick displays `v1.0.0 → 1.0.0` which is visually inconsistent. Non-blocking — fix can land as a follow-up to either client (display normalization) or backend (preserve input format).

## Test plan (post-merge)

- [ ] After tag v0.0.16 + ClawHub publish: confirm `clawhub inspect mapick` no new findings
- [ ] Re-check `security/static-analysis` page — should be clean
- [ ] Re-check `security/openclaw` page — "autonomous execution" finding should drop now that the trust statement is in CLAWHUB.md and execution requires explicit confirm
- [ ] Test the full notify_setup flow on a real install: opt-out detection → plan → user confirms → AI runs `openclaw cron add` → daily fires