### PR TITLE
fix(security+clean): local fallbacks when backend unreachable + inline rendering

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -44,7 +44,18 @@ Always render: `openclaw skills install <slug>`. Slug resolution:
 
 NEVER show or run: raw `installCommands[].command`, `skillssh:` prefixes, full `org/repo/skill` paths, `npx @mapick/install`, or `clawhub install skillssh:...`. Applies to **both** recommendation install and bundle install.
 
-Rendering: `reference/rendering.md#recommend` and `#search`.
+### Rendering: recommend / search
+
+Filter `score < 0.4`. Show **3 items max**. For each item render exactly **two sentences** — no tables, no bulleted field lists:
+
+1. **Sentence 1 — the gap**: one concrete thing the user does manually today. Reference something they said, installed, or do. ("You merge ~12 PRs a week and review them by eyeballing the diff.")
+2. **Sentence 2 — the fix**: inline the skill name + safety badge (🟢A / 🟡B / 🔴C) inside prose, then say what manual work disappears. ("Code Review 🟢A turns that into one comment per blocker.")
+
+Append install count ONLY when ≥10K, as a trailing social-proof clause ("trusted by 23K teams"). Never as a separate field. Grade C → use `alternatives[0]` instead and write the same two sentences about it. Open with a problem statement, not a catalog. Close with: "These three close your <area> loop. Reply 1 / 2 / 3 to install, or 'install all'."
+
+NEVER show raw `score` numbers, or render as a markdown table or bulleted catalog like `- Skill — benefit — 🟢A — 23K installs`. The user should feel "this is for ME", not "here are some products".
+
+For `search` with empty `items` (or `emptyReason: "no_matches"`): suggest broadening keywords, picking a category, or running `recommend` instead. Otherwise render like `recommend` (3-5 items max).
 
 ---
 
@@ -105,10 +116,13 @@ Command: `/mapick security <skillId>`
 Backend returns `matched: true` (with grade) or `matched: false` (with `suggestions[]`).
 
 Display rule (STRICT):
-- **Grade A** — celebrate, make user feel good.
-- **Grade B** — create tension, explain elevated signals, end "install anyway, or check the alternative?"
-- **Grade C** — dramatic reveal: "🚫 I would NOT install this." Lead with worst finding, show alternatives. **DO NOT show C-grade as installable.**
-- `lastScannedAt: null` — say "not yet scanned".
+- **Grade A** — celebrate. "✅ Clean bill of health. No suspicious code, permissions match what it actually uses, community trusts it." Make user feel good.
+- **Grade B** — create tension. "⚠️ Not a dealbreaker, but worth knowing..." Explain what specific signals are elevated. ("It requests network:all but only uses network:api — like asking for a master key when it only needs one room.") End: "Install anyway, or check the alternative?"
+- **Grade C** — **dramatic reveal.** "🚫 I would NOT install this." Lead with worst finding first (eval(), rm -rf, data exfil pattern). Then "Here's what I'd use instead:" → show `alternatives[]` with their Grade A scores. **DO NOT show the C-grade skill as installable.**
+- `lastScannedAt: null` — "⚠️ This skill hasn't been scanned yet. That doesn't mean it's bad — nobody's checked. Proceed with caution or wait for a scan."
+- `local_scan: true` — backend was unreachable; the result is a local pattern-only scan. Tell the user explicitly ("Backend unreachable, this is a local-only pattern scan; permissions/community signals not available") before applying the Grade A/B/C tone.
+
+When `matched: false`, render `suggestions[]` as a numbered short list and ask which one the user meant; on pick, re-call `security <picked.skillId>`.
 
 ### Intent: security:report
 Triggers: report X as malicious, flag X, X is suspicious.
@@ -170,15 +184,24 @@ Full install flow + failure playbook: `reference/flows.md#bundle-two-step-instal
 Triggers: clean, zombies, dead skills, prune.
 Command: `node scripts/shell.js clean`
 
-Open with impact (not count). Split: "Never used" vs "Used to be useful". End with: "Reply 'clean all' or pick numbers."
+### Rendering: clean
 
-On user pick: `clean:track <skillId>` then `uninstall <skillId> --confirm`.
+1. **Open with impact, not count.** Not "Found N zombie skills" but: "Your agent is carrying N dead skills. They eat <X>% of your context window every conversation — you're paying in speed and compute for zero value back."
+2. **Split into two groups:**
+   - "Never used (why did you install these?):" — 0 calls. Show install date: "installed 61 days ago, never once used".
+   - "Used to be useful:" — calls but idle 30+ days. Show last use date: "last used 47 days ago".
+3. **Before/after:** "Clean all N → context drops from <X>% to <Y>%, every response gets faster."
+4. **Make cleanup easy:** "Reply 'clean all' to remove everything, or pick numbers (e.g. '1-8 15 17')."
+
+Goal: user feels slightly embarrassed about hoarding, then satisfied after cleaning.
+
+On user pick: numbers → look up skillIds from last list, run `clean:track <id>` then `uninstall <id> --confirm` per skill. `all` → apply to every zombie. `skip` → reply "ok". Reason is `zombie_cleanup` (server-side); do NOT ask the user for one.
+
+`local_heuristic: true` in the response means the backend was unreachable / the user opted out — say so explicitly ("Backend unreachable; this is local heuristics only — last-modified > 30 days. Backend usage data not available").
 
 ### Intent: uninstall
 Triggers: uninstall, remove skill, delete skill.
 Command: `node scripts/shell.js uninstall <skillId> --confirm`. Default `--scope both`.
-
-Impact-first template: `reference/rendering.md#clean`.
 
 ---
 
@@ -212,8 +235,44 @@ On new Mapick session, run `node scripts/shell.js init` (idempotent, 30-min cool
 
 If CONFIG.md lacks `first_run_complete`: run `node scripts/shell.js summary`, render the summary card, ask one workflow question, then on answer call `profile set` + `recommend --with-profile` + `first-run-done`. Output summary AND question in a SINGLE response.
 
+### Rendering: summary card
+
+```
+mapick: 📊 Scan complete. Here's what I found.
+
+🔒 Privacy
+Your redaction engine is live — <privacy_rules> rules active.
+Provider access strings, certificates, and personal IDs → auto-stripped
+before any skill can see them.
+
+📦 Your skill inventory
+<total> installed — but let's be honest:
+  ✅ <active> you actually use
+  ⚠️ <never_used> you've NEVER used (why are these here?)
+  💤 <idle_30> you stopped using over a month ago
+That's a <activation_rate> activation rate.
+
+🔥 Your heavy hitters
+1. <top_used[0].name>      <top_used[0].daily>x/day — your workhorse
+2. <top_used[1].name>      <top_used[1].daily>x/day
+3. <top_used[2].name>      <top_used[2].daily>x/day
+
+🛡️ Safety check
+<security.A> skills passed (Grade A)
+<security.B> flagged minor issues (Grade B)
+<security.C> I wouldn't trust (Grade C) — say "security <name>" to see why
+
+⚡ The bottom line
+<zombie_count> zombie skills are eating <context_waste_pct>% of your
+context window. Every conversation, your agent loads them for nothing.
+
+🔒 Outbound: anonymous device id + skill IDs you act on + timestamps.
+   Audit: /mapick privacy log    Decline: /mapick privacy decline
+```
+
+If `never_used == 0 && idle_30 == 0`: skip negativity → "Clean setup. Top 10%." If `total <= 3`: skip the zombie angle → "Just getting started — let me find tools that match your workflow." If `has_backend: false`: skip the heavy-hitters + safety-check sections; say "Backend offline; counts only."
+
 Full 6-step flow: `reference/flows.md#first-run-summary`.
-Summary card layout: `reference/rendering.md#summary-card`.
 
 ---
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,18 @@
 
 All notable changes to Mapick will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `/mapick security <id>` falls back to a local AST-pattern scan when the backend errors. Patterns mirror mapick-api's `astPatterns` so local + backend grades use the same rule table. Local results carry `local_scan: true` and only score the code-analysis dimension; permissions / community / alternatives need server state.
+- `/mapick clean` now runs a local last-modified heuristic when the user has opted out (`consent_declined`) or the backend is unreachable. Response carries `local_heuristic: true` plus a reason ("consent_declined" or "backend_unreachable") for the AI to disclose to the user.
+
+### Changed
+
+- SKILL.md inlines the recommend / search / clean / summary-card / security-grade rendering rules that previously lived only in `reference/rendering.md`. AI doesn't reliably auto-load reference/ files, so the most-used templates now sit alongside their intent.
+- `clean` removed from `REMOTE_COMMANDS` (lib/core.js): the handler decides per-call whether to hit the backend now that local fallback is reliable.
+
 ## v0.0.15 - 2026-04-29
 
 ### Changed

--- a/scripts/lib/clean.js
+++ b/scripts/lib/clean.js
@@ -4,9 +4,10 @@ const fs = require("fs");
 const path = require("path");
 const {
   OUT_ARR, SKILLS_BASE, TRASH_DIR,
-  isoNow, isProtected,
+  isoNow, isProtected, isConsentDeclined,
 } = require("./core");
 const { httpCall, apiCall, missingArg } = require("./http");
+const { scanSkills } = require("./skills");
 
 function backupSkill(skillPath) {
   if (!fs.existsSync(TRASH_DIR)) fs.mkdirSync(TRASH_DIR, { recursive: true });
@@ -29,16 +30,53 @@ function backupSkill(skillPath) {
   return backupPath;
 }
 
+// Local heuristic: a zombie is any installed skill whose SKILL.md hasn't
+// been touched in MAPICK_ZOMBIE_DAYS days (default 30). Backend has richer
+// signal (actual invoke counts) but the mtime heuristic is still useful for
+// declined users and when the backend is offline.
+function localZombies() {
+  const zombieDays = parseInt(process.env.MAPICK_ZOMBIE_DAYS || "30", 10);
+  const cutoff = Date.now() - zombieDays * 86_400_000;
+  return scanSkills()
+    .filter((s) => !isProtected(s.id))
+    .filter((s) => new Date(s.last_modified).getTime() < cutoff)
+    .slice(0, OUT_ARR)
+    .map((s) => ({
+      skillId: s.id,
+      skillName: s.name,
+      lastUsedAt: s.last_modified,
+      installedAt: s.installed_at,
+      reason: "idle_30d",
+    }));
+}
+
 async function handleClean(_args, ctx) {
+  // Declined users skip the backend entirely — local-only by design.
+  if (isConsentDeclined(ctx.config)) {
+    return {
+      intent: "clean",
+      local_heuristic: true,
+      reason: "consent_declined",
+      zombies: localZombies(),
+    };
+  }
+
   const cleanResp = await httpCall(
     "GET",
     `/users/${ctx.fp}/zombies?limit=${OUT_ARR}`,
   );
-  // The previous shape `cleanResp.zombies || cleanResp || []` let backend
-  // error objects ({error, statusCode}) leak through as the zombies array
-  // because `error` is truthy. Pass errors through explicitly; otherwise
-  // accept either a top-level array or {zombies: [...]} shape.
-  if (cleanResp && cleanResp.error) return cleanResp;
+  // Network / 5xx from backend → fall back to local heuristic instead of
+  // surfacing an error. Pre-existing behavior leaked the error object as
+  // the zombies array (it's truthy).
+  if (cleanResp && cleanResp.error) {
+    return {
+      intent: "clean",
+      local_heuristic: true,
+      reason: "backend_unreachable",
+      backend_error: cleanResp.error,
+      zombies: localZombies(),
+    };
+  }
   return {
     intent: "clean",
     zombies: Array.isArray(cleanResp) ? cleanResp : (cleanResp?.zombies || []),

--- a/scripts/lib/core.js
+++ b/scripts/lib/core.js
@@ -22,7 +22,11 @@ const SCAN_LIMIT = parseInt(process.env.MAPICK_SCAN_LIMIT || "50", 10);
 const VALID_TRACK_ACTIONS = ["shown", "click", "install", "installed", "ignore", "not_interested"];
 const VALID_EVENT_ACTIONS = ["skill_install", "skill_invoke", "skill_idle", "skill_uninstall", "rec_shown", "rec_click", "rec_ignore", "rec_installed", "sequence_pattern"];
 const PROTECTED_SKILLS = ["mapick", "tasa"];
-const REMOTE_COMMANDS = new Set(["recommend", "recommend:track", "search", "workflow", "daily", "weekly", "report", "security", "security:report", "clean", "clean:track", "share"]);
+// `clean` is intentionally NOT here — handleClean falls back to a local
+// last-modified heuristic when the user has declined data sharing or the
+// backend is unreachable, so it works in all states. `clean:track` (consent
+// reporting) and `security` (now with local fallback) stay remote.
+const REMOTE_COMMANDS = new Set(["recommend", "recommend:track", "search", "workflow", "daily", "weekly", "report", "security", "security:report", "clean:track", "share"]);
 
 function detectSkillsBase() {
   return path.join(os.homedir(), ".openclaw", "skills");

--- a/scripts/lib/security-patterns.js
+++ b/scripts/lib/security-patterns.js
@@ -1,0 +1,34 @@
+// Risk patterns for offline /mapick security <id> fallback.
+//
+// Mirrors the AST-pattern subset of mapick-api's security.service.ts so that
+// local + backend grades stay aligned (same rule = same penalty). Backend
+// reference: src/modules/security/security.service.ts (`astPatterns` array).
+//
+// Local fallback only covers the "code-analysis" dimension. Backend additionally
+// scores permissions, community feedback, and external data — those need server
+// state, so an offline scan can't reproduce them and we mark the result with
+// `local_scan: true` so the AI can disclose the limitation.
+
+module.exports = [
+  // critical
+  { pattern: /\beval\s*\(/, penalty: 20, desc: "eval() dynamic execution", severity: "critical" },
+  { pattern: /\bnew\s+Function\s*\(/, penalty: 20, desc: "new Function() dynamic constructor", severity: "critical" },
+  { pattern: /require\s*\(\s*['"]child_process['"]/, penalty: 20, desc: "require child_process", severity: "critical" },
+  { pattern: /from\s+['"]child_process['"]/, penalty: 20, desc: "import child_process", severity: "critical" },
+  { pattern: /\bexecSync\s*\(/, penalty: 18, desc: "execSync() shell", severity: "critical" },
+  { pattern: /rm\s+-rf/, penalty: 25, desc: "rm -rf delete command", severity: "critical" },
+  { pattern: /process\.env\.\w+.*(?:send|post|fetch|axios|request)/i, penalty: 15, desc: "env variable exfiltration pattern", severity: "critical" },
+  { pattern: /`[^`]*(?:rm|dd|mkfs|format)[^`]*`/, penalty: 20, desc: "backtick shell injection", severity: "critical" },
+
+  // high
+  { pattern: /\bexec\s*\(/, penalty: 15, desc: "exec() shell call", severity: "high" },
+  { pattern: /\bspawn\s*\(/, penalty: 15, desc: "spawn() child process", severity: "high" },
+  { pattern: /\\x[0-9a-f]{2}(?:\\x[0-9a-f]{2}){3,}/i, penalty: 15, desc: "hex byte sequence (obfuscation)", severity: "high" },
+  { pattern: /require\s*\(\s*['"]vm['"]/, penalty: 10, desc: "require vm (sandbox escape risk)", severity: "high" },
+
+  // medium
+  { pattern: /\batob\s*\(|base64_decode/, penalty: 10, desc: "base64 decode (possible obfuscation)", severity: "medium" },
+  { pattern: /String\.fromCharCode\s*\(/, penalty: 10, desc: "fromCharCode obfuscation", severity: "medium" },
+  { pattern: /\$\(.*\)/, penalty: 10, desc: "shell command substitution $()", severity: "medium" },
+  { pattern: /https?:\/\/(?!(?:api\.|cdn\.|github\.com|npmjs\.com))\S{20,}/, penalty: 5, desc: "suspicious hardcoded URL", severity: "medium" },
+];

--- a/scripts/lib/security.js
+++ b/scripts/lib/security.js
@@ -1,10 +1,133 @@
 // security / security:report handlers.
+//
+// /mapick security <id> tries the backend first, then falls back to a local
+// pattern scan (lib/security-patterns.js) when the backend is unreachable.
+// Local results carry `local_scan: true` so the AI can disclose the limitation.
 
+const fs = require("fs");
+const path = require("path");
 const { apiCall, missingArg } = require("./http");
+const { SKILLS_BASE, OUT_ARR, isoNow } = require("./core");
+const RISK_PATTERNS = require("./security-patterns");
+
+const MAX_FILES = 30;
+const MAX_BYTES = 200 * 1024;
+const SCANNABLE_EXT = /\.(js|mjs|cjs|ts|tsx|sh|bash)$/i;
+const SKIP_DIRS = new Set(["node_modules", ".git", "trash", "dist", "build"]);
+
+function listScannableFiles(dir, files = [], totalBytes = { v: 0 }) {
+  if (files.length >= MAX_FILES || totalBytes.v >= MAX_BYTES) return files;
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    if (files.length >= MAX_FILES || totalBytes.v >= MAX_BYTES) break;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      listScannableFiles(full, files, totalBytes);
+    } else if (entry.isFile()) {
+      const isManifest = entry.name === "SKILL.md";
+      if (!isManifest && !SCANNABLE_EXT.test(entry.name)) continue;
+      let stat;
+      try { stat = fs.statSync(full); } catch { continue; }
+      if (stat.size > 1_000_000) continue;
+      totalBytes.v += stat.size;
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function scanLocal(skillId) {
+  const skillDir = path.join(SKILLS_BASE, skillId);
+  if (!fs.existsSync(skillDir)) {
+    return { ok: false, reason: "not_installed_locally" };
+  }
+  const files = listScannableFiles(skillDir);
+  if (files.length === 0) {
+    return { ok: false, reason: "no_scannable_files" };
+  }
+
+  let codeScore = 100;
+  const issues = [];
+  for (const file of files) {
+    let content;
+    try { content = fs.readFileSync(file, "utf8"); } catch { continue; }
+    for (const { pattern, penalty, desc, severity } of RISK_PATTERNS) {
+      if (pattern.test(content)) {
+        codeScore -= penalty;
+        issues.push({
+          file: path.relative(skillDir, file),
+          pattern: desc,
+          severity,
+        });
+      }
+    }
+  }
+  codeScore = Math.max(0, codeScore);
+
+  let grade;
+  if (codeScore >= 80) grade = "A";
+  else if (codeScore >= 50) grade = "B";
+  else grade = "C";
+
+  return { ok: true, grade, codeScore, issues, filesScanned: files.length };
+}
 
 async function handleSecurity(args) {
   if (args.length < 1) return missingArg("Usage: security <skillId>");
-  return apiCall("GET", `/skill/${args[0]}/security`, null, "security");
+  const skillId = args[0];
+  const remote = await apiCall("GET", `/skill/${skillId}/security`, null, "security");
+  if (!remote.error) return remote;
+
+  const local = scanLocal(skillId);
+  if (!local.ok) {
+    return {
+      intent: "security",
+      matched: false,
+      local_scan: true,
+      skillId,
+      reason: local.reason,
+      backend_error: remote.error,
+      hint:
+        local.reason === "not_installed_locally"
+          ? "Skill not installed locally; can't scan offline. Try again when the backend is reachable."
+          : "No scannable code in skill directory. Try again when the backend is reachable.",
+    };
+  }
+
+  const top = local.issues.slice(0, OUT_ARR);
+  const summary = top.length
+    ? top.map((i) => i.pattern).slice(0, 3).join("; ")
+    : "no risk patterns detected";
+
+  return {
+    intent: "security",
+    matched: true,
+    local_scan: true,
+    skillId,
+    skillName: skillId,
+    safetyGrade: local.grade,
+    scoreBreakdown: {
+      codeAnalysis: local.codeScore,
+      permissionAnalysis: null,
+      communityFeedback: null,
+      externalData: null,
+    },
+    signals: {
+      code_issues: top,
+      networkRequests: [],
+    },
+    detailsEn: `Local scan (${local.filesScanned} files): ${summary}.`,
+    alternatives: [],
+    lastScannedAt: isoNow(),
+    note: "Backend unavailable; this is a local pattern-only scan covering the code-analysis dimension. Permissions, community feedback, and alternatives are not available offline.",
+    backend_error: remote.error,
+  };
 }
 
 async function handleReport(args) {


### PR DESCRIPTION
## Summary

Three independent fixes flagged from the previous review:

- **P1-A — `/mapick security <id>` had no offline path.** Now falls back to a local AST-pattern scan when the backend errors. New `lib/security-patterns.js` mirrors mapick-api's `astPatterns` so local + backend grades use the same penalty table. Local results carry `local_scan: true` (code-analysis dimension only) and the response includes a `note` for the AI to disclose the limitation. Skips `node_modules` / `.git` / `trash` / `dist` / `build`; bounded at 30 files / 200KB per scan.

- **P1-B — Common rendering rules lived in `reference/rendering.md`, AI didn't reliably auto-load them.** Inlined the most-used templates (recommend / search / clean / summary-card / security Grade A·B·C) into SKILL.md alongside their intents. Reference rendering.md still holds the long versions for any AI that does load it.

- **P2 — `/mapick clean` was blocked client-side for opt-out users + leaked backend errors as the zombies array.** Removed `clean` from `REMOTE_COMMANDS`; handler now skips the backend for declined users, falls back to a local last-modified heuristic on backend failure, and carries `local_heuristic: true` + a reason ("consent_declined" / "backend_unreachable") so the AI can disclose the degraded mode.

Each commit is independently reviewable.

## Test plan

- [x] `MAPICK_API_BASE=http://127.0.0.1:1 node scripts/shell.js security mapick` → returns Grade with `local_scan: true`, `signals.code_issues[]`, and the disclaimer note
- [x] Same command for an uninstalled skill → `matched: false`, `reason: "not_installed_locally"`
- [x] `MAPICK_API_BASE=http://127.0.0.1:1 node scripts/shell.js clean` → `local_heuristic: true`, `reason: "backend_unreachable"`
- [x] `privacy consent-decline` then `clean` → `local_heuristic: true`, `reason: "consent_declined"` (no remote call made)
- [x] `privacy consent-decline` then `security <id>` → still blocked by `disabled_in_local_mode` (kept in REMOTE_COMMANDS — local fallback only triggers on backend errors, not opt-out, to avoid sending fp header for declined users)
- [ ] Live backend reachable → unchanged behavior (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)