### PR TITLE
feat(install): atomic install.sh — staging + backup + rollback (closes #19)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Mapick Skill — Install Script (V1: OpenClaw only)
+# Mapick Skill — Install Script (atomic install pipeline)
 #
 # Recommended install path is `clawhub install mapick`. This script is for
 # recovery, CI, pinned versions, or environments without ClawHub access.
@@ -10,9 +10,15 @@
 #   bash install.sh
 #
 # Options (via environment variables):
-#   MAPICK_VERSION=v0.0.15  ./install.sh   # Install specific version
-#   MAPICK_REPO=owner/repo ./install.sh   # Override source repo
-#   MAPICK_DISABLE_WORKSPACE_DUPLICATE=1  # Move shadowing workspace copy aside
+#   MAPICK_VERSION=v0.0.15                  Install specific version
+#   MAPICK_REPO=owner/repo                  Override source repo
+#   MAPICK_DISABLE_WORKSPACE_DUPLICATE=1    Move shadowing workspace copy aside
+#   MAPICK_INSTALL_ASSUME_YES=1             Auto-accept overwrite/upgrade
+#   MAPICK_INSTALL_DRY_RUN=1                Preflight only, no download or write
+#   MAPICK_INSTALL_JSON=1                   Emit machine-readable JSON progress
+#   MAPICK_INSTALL_FORCE_DOWNGRADE=1        Allow installing over a newer version
+#   MAPICK_INSTALL_FORCE_OVERWRITE=1        Allow installing over unknown source
+#   MAPICK_INSTALL_BACKUP_KEEP=3            How many backups to retain (default 3)
 
 set -e
 
@@ -20,6 +26,13 @@ set -e
 
 REPO="${MAPICK_REPO:-mapick-ai/mapick}"
 VERSION="${MAPICK_VERSION:-latest}"
+
+ASSUME_YES="${MAPICK_INSTALL_ASSUME_YES:-0}"
+DRY_RUN="${MAPICK_INSTALL_DRY_RUN:-0}"
+JSON_MODE="${MAPICK_INSTALL_JSON:-0}"
+FORCE_DOWNGRADE="${MAPICK_INSTALL_FORCE_DOWNGRADE:-0}"
+FORCE_OVERWRITE="${MAPICK_INSTALL_FORCE_OVERWRITE:-0}"
+BACKUP_KEEP="${MAPICK_INSTALL_BACKUP_KEEP:-3}"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -30,33 +43,79 @@ BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
 
-info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
-ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
-warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
-error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+# -- Output helpers ------------------------------------------------------------
+# JSON mode: machine-readable single-line events on stdout, no colors.
+# Human mode: existing colored output.
+
+json_event() {
+  if [[ "${JSON_MODE}" != "1" ]]; then return 0; fi
+  local type="$1"; shift
+  local out="{\"event\":\"${type}\""
+  while [[ $# -gt 0 ]]; do
+    local kv="$1"; shift
+    local k="${kv%%=*}"
+    local v="${kv#*=}"
+    # Escape JSON special chars: backslash, quote, newline, tab, CR.
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    v="${v//$'\n'/\\n}"
+    v="${v//$'\r'/\\r}"
+    v="${v//$'\t'/\\t}"
+    out+=",\"${k}\":\"${v}\""
+  done
+  out+="}"
+  echo "${out}"
+}
+
+info()  {
+  if [[ "${JSON_MODE}" == "1" ]]; then json_event info msg="$*"; else echo -e "${BLUE}[INFO]${NC}  $*"; fi
+}
+ok()    {
+  if [[ "${JSON_MODE}" == "1" ]]; then json_event ok msg="$*"; else echo -e "${GREEN}[OK]${NC}    $*"; fi
+}
+warn()  {
+  if [[ "${JSON_MODE}" == "1" ]]; then json_event warn msg="$*"; else echo -e "${YELLOW}[WARN]${NC}  $*"; fi
+}
+error() {
+  if [[ "${JSON_MODE}" == "1" ]]; then
+    json_event error msg="$*"
+  else
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+  fi
+  exit 1
+}
+dim_echo() {
+  if [[ "${JSON_MODE}" != "1" ]]; then echo -e "${DIM}$*${NC}"; fi
+}
 
 # -- Banner --------------------------------------------------------------------
 
-echo ""
-echo -e "${CYAN}"
-echo '  ╔══════════════════════════════════════════╗'
-echo '  ║                                          ║'
-echo '  ║              M A P I C K                 ║'
-echo '  ║       Mapick Intelligent Butler          ║'
-echo '  ║                                          ║'
-echo '  ╚══════════════════════════════════════════╝'
-echo -e "${NC}"
+if [[ "${JSON_MODE}" != "1" ]]; then
+  echo ""
+  echo -e "${CYAN}"
+  echo '  ╔══════════════════════════════════════════╗'
+  echo '  ║                                          ║'
+  echo '  ║              M A P I C K                 ║'
+  echo '  ║       Mapick Intelligent Butler          ║'
+  echo '  ║                                          ║'
+  echo '  ╚══════════════════════════════════════════╝'
+  echo -e "${NC}"
+fi
+
+json_event start version="${VERSION}" repo="${REPO}" dry_run="${DRY_RUN}"
 
 # -- Resolve version -----------------------------------------------------------
 
 if [[ "${VERSION}" == "latest" ]]; then
   info "Fetching latest version..."
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+  RESOLVED_VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
     | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/') || true
 
-  if [[ -z "${VERSION}" ]]; then
+  if [[ -z "${RESOLVED_VERSION}" ]]; then
     warn "Cannot fetch latest release, falling back to main branch"
     VERSION="main"
+  else
+    VERSION="${RESOLVED_VERSION}"
   fi
 fi
 
@@ -124,7 +183,7 @@ if [[ -f "${workspace_skill_dir}/SKILL.md" ]] \
     disabled_dir="${HOME}/.openclaw/workspace/mapick.disabled-$(date +%Y%m%d-%H%M%S)"
     mv "${workspace_skill_dir}" "${disabled_dir}"
     ok "Moved shadowing workspace copy to:"
-    echo -e "    ${DIM}${disabled_dir}${NC}"
+    dim_echo "    ${disabled_dir}"
   else
     echo "To use the newly installed version, move the workspace copy aside and"
     echo "restart the gateway:"
@@ -138,21 +197,128 @@ if [[ -f "${workspace_skill_dir}/SKILL.md" ]] \
   fi
 fi
 
+# -- Resolve install paths -----------------------------------------------------
+
+target_dir="${HOME}/.openclaw/skills/mapick"
+parent_dir="$(dirname "${target_dir}")"
+target_name="$(basename "${target_dir}")"
+staging_dir="${parent_dir}/.${target_name}.tmp-$$"
+backup_dir="${parent_dir}/.${target_name}.backup-$(date +%Y%m%d-%H%M%S)"
+
+# -- Preflight conflict classification -----------------------------------------
+# Possible states:
+#   - not_installed       — target_dir absent; install fresh
+#   - same_version        — .version equals VERSION; skip with exit 0
+#   - older_version       — .version semver < VERSION; backup + upgrade
+#   - newer_version       — .version semver > VERSION; refuse unless force
+#   - unknown_source      — dir exists, no .version; refuse unless force
+
+semver_to_int() {
+  # vX.Y.Z[-suffix] → X*1e6 + Y*1e3 + Z (suffix ignored)
+  local v="${1#v}"
+  v="${v%%-*}"
+  IFS='.' read -r maj min pat <<<"${v}"
+  maj="${maj:-0}"; min="${min:-0}"; pat="${pat:-0}"
+  if ! [[ "${maj}" =~ ^[0-9]+$ ]] || ! [[ "${min}" =~ ^[0-9]+$ ]] || ! [[ "${pat}" =~ ^[0-9]+$ ]]; then
+    echo "0"; return
+  fi
+  echo $(( maj * 1000000 + min * 1000 + pat ))
+}
+
+CONFLICT_STATE="not_installed"
+CURRENT_VERSION=""
+if [[ -d "${target_dir}" ]]; then
+  if [[ -f "${target_dir}/.version" ]]; then
+    CURRENT_VERSION="$(head -1 "${target_dir}/.version" | tr -d '[:space:]')"
+    if [[ "${CURRENT_VERSION}" == "${VERSION}" ]]; then
+      CONFLICT_STATE="same_version"
+    else
+      cur_int="$(semver_to_int "${CURRENT_VERSION}")"
+      new_int="$(semver_to_int "${VERSION}")"
+      if (( cur_int < new_int )); then
+        CONFLICT_STATE="older_version"
+      elif (( cur_int > new_int )); then
+        CONFLICT_STATE="newer_version"
+      else
+        # equal as int but string-different (e.g. main vs v0.0.15) — treat as upgrade
+        CONFLICT_STATE="older_version"
+      fi
+    fi
+  else
+    CONFLICT_STATE="unknown_source"
+  fi
+fi
+
+json_event preflight state="${CONFLICT_STATE}" current_version="${CURRENT_VERSION}" target_version="${VERSION}"
+
+case "${CONFLICT_STATE}" in
+  not_installed)
+    info "Fresh install (target dir does not exist)."
+    ;;
+  same_version)
+    ok "Already at ${VERSION} — nothing to do."
+    json_event done state="same_version"
+    if [[ "${JSON_MODE}" != "1" ]]; then
+      echo ""
+      echo -e "  ${BLUE}Tip:${NC} If \`/mapick\` doesn't show in your current OpenClaw"
+      echo "  conversation, start a new session — skill snapshots are loaded once"
+      echo "  per session."
+    fi
+    exit 0
+    ;;
+  older_version)
+    info "Upgrade ${CURRENT_VERSION} → ${VERSION}"
+    ;;
+  newer_version)
+    if [[ "${FORCE_DOWNGRADE}" != "1" ]]; then
+      error "Refusing to downgrade ${CURRENT_VERSION} → ${VERSION}.
+
+  The installed version is newer than the requested target. To override, set
+  MAPICK_INSTALL_FORCE_DOWNGRADE=1 and re-run this script."
+    fi
+    warn "Forcing downgrade ${CURRENT_VERSION} → ${VERSION} (MAPICK_INSTALL_FORCE_DOWNGRADE=1)"
+    ;;
+  unknown_source)
+    if [[ "${FORCE_OVERWRITE}" != "1" && "${ASSUME_YES}" != "1" ]]; then
+      error "An unrecognized Mapick install exists at ${target_dir} (no .version file).
+
+  This may be from a manual extraction or a fork. To overwrite it, set
+  MAPICK_INSTALL_FORCE_OVERWRITE=1 (or MAPICK_INSTALL_ASSUME_YES=1) and
+  re-run this script. The current contents will be moved to a timestamped
+  backup before the install."
+    fi
+    warn "Overwriting unrecognized install at ${target_dir}"
+    ;;
+esac
+
+# -- Dry-run exit --------------------------------------------------------------
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  ok "Dry run complete — no files written."
+  json_event done state="dry_run" planned_state="${CONFLICT_STATE}"
+  exit 0
+fi
+
 # -- Download tarball ----------------------------------------------------------
 
 REF="${VERSION}"
 TARBALL_URL="https://github.com/${REPO}/archive/${REF}.tar.gz"
 
 echo ""
-echo -e "${DIM}────────────────────────────────────────${NC}"
+dim_echo "────────────────────────────────────────"
 echo ""
 info "Downloading Mapick Skill (${VERSION})..."
+json_event download url="${TARBALL_URL}"
 
 TMP_DIR=$(mktemp -d)
-trap "rm -rf ${TMP_DIR}" EXIT
 
-# Download to file first (curl --retry needs a clean restart point; piping into
-# tar makes retries useless because tar has already consumed partial data).
+# Cleanup hook: remove TMP_DIR + staging_dir if still present (failure cases).
+cleanup() {
+  rm -rf "${TMP_DIR}"
+  [[ -d "${staging_dir}" ]] && rm -rf "${staging_dir}"
+}
+trap cleanup EXIT
+
 TARBALL="${TMP_DIR}/mapick.tar.gz"
 if ! curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
      "${TARBALL_URL}" -o "${TARBALL}"; then
@@ -167,73 +333,130 @@ rm -f "${TARBALL}"
 
 ok "Download complete"
 
-# -- Install to OpenClaw -------------------------------------------------------
+# -- Stage to .mapick.tmp-<pid>/ -----------------------------------------------
 
-target_dir="${HOME}/.openclaw/skills/mapick"
+info "Staging install to ${staging_dir}"
+json_event stage path="${staging_dir}"
 
-echo ""
-info "Installing to ${BOLD}OpenClaw${NC} ..."
+mkdir -p "${staging_dir}"
 
-# Preserve user-editable CONFIG.md across upgrades
-BACKUP_CONFIG=""
-if [[ -f "${target_dir}/CONFIG.md" ]]; then
-  BACKUP_CONFIG="$(mktemp)"
-  cp "${target_dir}/CONFIG.md" "${BACKUP_CONFIG}"
-fi
-
-if [[ -d "${target_dir}" ]]; then
-  warn "Existing installation found, overwriting..."
-  rm -rf "${target_dir}"
-fi
-
-mkdir -p "${target_dir}"
-
-# Copy runtime files (Skill payload, not repo boilerplate).
-# Keep this list in sync with what SKILL.md references.
 INSTALL_ITEMS=(SKILL.md LICENSE scripts reference prompts)
 for item in "${INSTALL_ITEMS[@]}"; do
   if [[ -e "${TMP_DIR}/${item}" ]]; then
-    cp -R "${TMP_DIR}/${item}" "${target_dir}/"
+    cp -R "${TMP_DIR}/${item}" "${staging_dir}/"
   fi
 done
 
 # Ensure entry scripts are executable
 for exe in scripts/shell.js scripts/redact.js; do
-  [[ -f "${target_dir}/${exe}" ]] && chmod +x "${target_dir}/${exe}"
+  [[ -f "${staging_dir}/${exe}" ]] && chmod +x "${staging_dir}/${exe}"
 done
 
-# Restore user config if present
-if [[ -n "${BACKUP_CONFIG}" ]]; then
-  cp "${BACKUP_CONFIG}" "${target_dir}/CONFIG.md"
-  rm -f "${BACKUP_CONFIG}"
-  echo -e "    ${DIM}Restored: CONFIG.md${NC}"
+# Record installed version
+echo "${VERSION}" > "${staging_dir}/.version"
+
+# Verify staged install before touching the live target_dir
+if [[ ! -f "${staging_dir}/SKILL.md" ]] || [[ ! -f "${staging_dir}/scripts/shell.js" ]]; then
+  error "Staging failed — required files missing in ${staging_dir}."
 fi
 
-# Record installed version so `mapick notify` can compare against the latest
-# GitHub release at runtime. Plain text, single line.
-echo "${VERSION}" > "${target_dir}/.version"
+ok "Staged"
 
+# -- Backup existing target ----------------------------------------------------
+
+did_backup=0
+if [[ -d "${target_dir}" ]]; then
+  info "Backing up existing install to ${backup_dir}"
+  json_event backup from="${target_dir}" to="${backup_dir}"
+  cp -R "${target_dir}" "${backup_dir}"
+  did_backup=1
+fi
+
+# Preserve user state across upgrades. These survive even if user-content
+# files were removed in newer versions.
+preserve_user_state() {
+  local from="$1"
+  local to="$2"
+  for keep in CONFIG.md cache trash; do
+    if [[ -e "${from}/${keep}" ]]; then
+      cp -R "${from}/${keep}" "${to}/"
+      dim_echo "    Preserved: ${keep}"
+    fi
+  done
+}
+
+if [[ "${did_backup}" == "1" ]]; then
+  preserve_user_state "${backup_dir}" "${staging_dir}"
+fi
+
+# -- Atomic swap ---------------------------------------------------------------
+
+rollback() {
+  warn "Install failed — rolling back."
+  json_event rollback from="${backup_dir}" to="${target_dir}"
+  rm -rf "${target_dir}"
+  if [[ "${did_backup}" == "1" ]] && [[ -d "${backup_dir}" ]]; then
+    mv "${backup_dir}" "${target_dir}"
+  fi
+}
+
+info "Atomic swap → ${target_dir}"
+json_event swap target="${target_dir}"
+
+# Remove the old target dir; backup is already taken.
+if [[ -d "${target_dir}" ]]; then
+  rm -rf "${target_dir}"
+fi
+
+# mv staging to target. If this fails, rollback.
+if ! mv "${staging_dir}" "${target_dir}"; then
+  rollback
+  error "Atomic rename failed — original restored from backup."
+fi
+
+# Final verify after swap
 if [[ ! -f "${target_dir}/SKILL.md" ]] || [[ ! -f "${target_dir}/scripts/shell.js" ]]; then
-  error "Installation failed (required files missing after copy)."
+  rollback
+  error "Post-swap verification failed — required files missing. Rolled back."
 fi
 
-ok "OpenClaw installed successfully"
-echo -e "    ${DIM}${target_dir}/${NC}"
+ok "Installed at ${target_dir}"
+
+# -- Trim backups (keep most recent N) -----------------------------------------
+
+if [[ "${BACKUP_KEEP}" =~ ^[0-9]+$ ]] && (( BACKUP_KEEP > 0 )); then
+  shopt -s nullglob
+  backups=("${parent_dir}/.${target_name}".backup-*)
+  shopt -u nullglob
+  if (( ${#backups[@]} > BACKUP_KEEP )); then
+    IFS=$'\n' sorted=($(printf '%s\n' "${backups[@]}" | sort -r))
+    unset IFS
+    for ((i = BACKUP_KEEP; i < ${#sorted[@]}; i++)); do
+      rm -rf "${sorted[$i]}"
+      dim_echo "    Trimmed old backup: $(basename "${sorted[$i]}")"
+    done
+  fi
+fi
 
 # -- Summary -------------------------------------------------------------------
 
+json_event done state="${CONFLICT_STATE}" version="${VERSION}" target="${target_dir}"
+
+if [[ "${JSON_MODE}" == "1" ]]; then
+  exit 0
+fi
+
 echo ""
-echo -e "${DIM}────────────────────────────────────────${NC}"
+dim_echo "────────────────────────────────────────"
 echo ""
 
 ok "Done!"
 echo ""
 echo -e "  ${GREEN}Version${NC}: ${VERSION}"
+if [[ "${did_backup}" == "1" ]]; then
+  echo -e "  ${GREEN}Backup${NC}:  ${backup_dir}"
+fi
 echo ""
-
-# Note: the daily-9am notify cron is registered automatically by shell.js
-# after the user runs `/mapick privacy consent-agree 1.0`. Registering here
-# would fire before consent and the cron's daily-check would 403.
 
 echo -e "  ${BLUE}Get started:${NC}"
 echo "    /mapick                View status overview"


### PR DESCRIPTION
## Summary

Replace the previous \"rm -rf target; copy\" install flow with an atomic pipeline that stages to a temp dir, atomic-renames into place, and rolls back from a timestamped backup on any failure.

Closes #19.

## Pipeline

```
1. Resolve VERSION + paths
2. Preflight: classify target_dir state
3. (DRY_RUN exits here)
4. Download tarball → TMP, extract, verify
5. Stage to <skills>/.mapick.tmp-<pid>/
6. Backup existing → <skills>/.mapick.backup-<timestamp>/
7. Preserve user state (CONFIG.md / cache/ / trash/) into staging
8. Atomic rename: staging → target
9. Post-swap verify; rollback on failure
10. Trim backups to BACKUP_KEEP most recent (default 3)
```

## Conflict cases (5 of 6 from #19)

| State | Detection | Action |
| --- | --- | --- |
| `not_installed` | target_dir absent | install |
| `same_version` | `.version == VERSION` | skip exit 0 + new-session tip |
| `older_version` | semver(`.version`) < VERSION | backup + upgrade |
| `newer_version` | semver(`.version`) > VERSION | refuse unless `MAPICK_INSTALL_FORCE_DOWNGRADE=1` |
| `unknown_source` | dir exists, no `.version` | refuse unless `MAPICK_INSTALL_FORCE_OVERWRITE=1` (or `_ASSUME_YES=1`) |

The 6th case (`locally_modified` — hash diff vs install manifest) is **deferred**: there's no manifest yet to diff against. Filed as future work; the `unknown_source` path covers most of it.

## Env-var flags

| Flag | Behavior |
| --- | --- |
| `MAPICK_INSTALL_DRY_RUN=1` | preflight only — exits before download |
| `MAPICK_INSTALL_JSON=1` | line-delimited JSON progress events on stdout |
| `MAPICK_INSTALL_ASSUME_YES=1` | auto-accept overwrites of `unknown_source` |
| `MAPICK_INSTALL_FORCE_DOWNGRADE=1` | install over a newer version |
| `MAPICK_INSTALL_FORCE_OVERWRITE=1` | install over `unknown_source` |
| `MAPICK_INSTALL_BACKUP_KEEP=N` | backup retention (default `3`) |
| `MAPICK_INSTALL_NO_AUTO_DEPS=1` | (reserved — installer never auto-installs deps today, flag is forward-compat) |

## Test plan

- [x] `bash -n install.sh` — syntax clean
- [x] DRY_RUN with each conflict state — classifies correctly
- [x] Real fresh install — files copied, `.version` written, executables chmod'd
- [x] Same-version reinstall — skips with exit 0 + new-session tip
- [x] Upgrade path — old install backed up, CONFIG.md preserved into new
- [x] Refuse-newer — exits 1 without `MAPICK_INSTALL_FORCE_DOWNGRADE`
- [x] `FORCE_DOWNGRADE=1` — proceeds
- [x] Refuse `unknown_source` — exits 1 without `FORCE_OVERWRITE`
- [x] `FORCE_OVERWRITE=1` — proceeds
- [x] Backup retention — 6 backups → 3 after `BACKUP_KEEP=3`
- [x] JSON mode emits valid one-line JSON per event (newlines/quotes/backslash escaped)
- [ ] Manual: simulate Ctrl-C between staging and atomic-rename — confirm previous install survives (depends on shell trap; `cleanup` removes only `staging_dir`, never `target_dir`, before swap)

## Risks / notes

- The atomic rename is `mv staging target`. On Linux/macOS this is a true rename within the same filesystem (which it is — both under `~/.openclaw/skills/`). Cross-filesystem `mv` falls back to copy+rm; that's not atomic, but it's the same risk profile as the previous `cp -R` approach and only matters if `~/.openclaw/skills` straddles a mountpoint, which is unusual.
- BSD-style `sort -r` on filenames uses ASCII order. Backup dir names embed `YYYYMMDD-HHMMSS` so lexicographic sort = chronological sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)