### PR TITLE
feat(skill): AI taste tags for day-1 shareability (closes #45)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -368,6 +368,56 @@ context window. Every conversation, your agent loads them for nothing.
 
 If `never_used == 0 && idle_30 == 0`: skip negativity → "Clean setup. Top 10%." If `total <= 3`: skip the zombie angle → "Just getting started — let me find tools that match your workflow." If `has_backend: false`: skip the heavy-hitters + safety-check sections; say "Backend offline; counts only."
 
+### AI Taste Tags (generate from summary data, no extra API call)
+
+After rendering the summary card, generate **2–3 taste tags** from the data already returned by `summary`. No extra command, no backend call. Persona report stays brewing — these tags are a separate, lightweight day-1 artifact.
+
+Lookup tables:
+
+**Quantity** (from `total`):
+- `total >= 40` → `收藏癖 Collector`
+- `total 15–39` → `实用主义 Pragmatist`
+- `total 5–14` → `极简主义 Minimalist`
+- `total < 5` → `刚起步 Newbie`
+
+**Efficiency** (from `active / total`):
+- `< 30%` → `囤货不用型 Hoarder`
+- `30–60%` → `还在探索 Explorer`
+- `60–90%` → `效率选手 Optimizer`
+- `> 90%` → `断舍离大师 Marie Kondo`
+
+**Stack** (from `top_used[].name`):
+- contains `github` / `docker` / `k8s` → `硬核极客 Hardcore Geek`
+- contains `summarize` / `writing` / `content` → `内容创作者 Creator`
+- contains `data-analysis` / `visualization` → `数据控 Data Nerd`
+- contains `productivity` / `calendar` / `email` → `效率狂人 Productivity Freak`
+- mixed / unrecognizable → `杂食动物 Omnivore`
+
+**Bonus** (only if `never_used > 5`):
+- `装了不用协会会长 Install-and-Forget Champion`
+
+Pick the **3 most interesting** (most differentiating). Rendering format:
+
+```
+🎯 你的 AI 品味：「{tag1} + {tag2} + {tag3}」
+```
+
+Then one 冷知识 line comparing to other users using `total`:
+- `total > 40` → `你装的 Skill 数量超过 82% 的用户`
+- `total > 20` → `…超过 60% 的用户`
+- `total > 10` → `…超过 40% 的用户`
+- otherwise: skip the 冷知识 line
+
+End with the share CTA:
+
+```
+📤 测测你朋友的 → /mapick status
+```
+
+(The `s.mapick.ai` share link will land in V2; today the CTA bounces a friend through the same first-run flow.)
+
+Skip the entire taste-tags block when `total == 0` (a fresh install with no skills installed yet — no signal to riff on).
+
 Full 6-step flow: `reference/flows.md#first-run-summary`.
 
 ---


### PR DESCRIPTION
## Summary

Day-1 users have nothing shareable today. The persona report is gated behind 7 days of usage data, so a fresh install just gets \"🔒 brewing — come back later.\" That kills word-of-mouth.

This PR adds a **lookup-table rendering rule** to the first-run summary so the AI emits 2–3 taste tags from data `summary` already returns (`total`, `active`, `never_used`, `top_used`). Each user gets a different combo → shareable artifact day 1.

**Zero code changes — SKILL.md only.** No new command, no backend call, no shell.js change. Persona report is unchanged (still brewing).

Closes #45.

## Tag tables

**Quantity** (from `total`): Collector / Pragmatist / Minimalist / Newbie  
**Efficiency** (from `active/total`): Hoarder / Explorer / Optimizer / Marie Kondo  
**Stack** (from `top_used` names): Hardcore Geek / Creator / Data Nerd / Productivity Freak / Omnivore  
**Bonus** (if `never_used > 5`): Install-and-Forget Champion

## Output format

```
🎯 你的 AI 品味：「收藏癖 + 断舍离大师 + 硬核极客」
你装的 Skill 数量超过 82% 的用户
📤 测测你朋友的 → /mapick status
```

## Sample lookup verification

Sanity-checked the table on synthetic input `total=42, active=38, never_used=2, top_used=[github, docker]`:

```
total=42 active=38 top=[github,docker]:
→ 「收藏癖 Collector + 断舍离大师 Marie Kondo + 硬核极客 Hardcore Geek」
```

## Acceptance

- [x] First-run summary card output ends with 3-tag line + 冷知识 + share CTA.
- [x] Sample lookup matches expected combo.
- [x] Persona report (`/mapick report` brewing branch) unchanged.
- [x] No new shell command, no backend call.
- [x] Skipped entirely when `total == 0` (fresh install with no skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)