### PR TITLE
feat(install): detect non-POSIX shell + bail with WSL hint (closes #12)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,33 @@
 
 set -e
 
+# -- Platform check ------------------------------------------------------------
+# `install.sh` is bash-only. On Windows, OpenClaw users should run install via
+# WSL (Linux subsystem) — Git Bash / Cygwin / MSYS / MINGW environments don't
+# have the symlink + chmod + permissions semantics OpenClaw assumes, and
+# silently miscopying files there has historically wedged the install. Bail
+# before any destructive write.
+case "$(uname -s 2>/dev/null)" in
+  Linux*|Darwin*)
+    : # POSIX path, OK to proceed
+    ;;
+  CYGWIN*|MSYS*|MINGW*|MSYS_NT*|MINGW64_NT*|MINGW32_NT*)
+    echo "ERROR: install.sh detected a non-POSIX shell ($(uname -s))." >&2
+    echo "" >&2
+    echo "On Windows, install Mapick via WSL (Windows Subsystem for Linux):" >&2
+    echo "  1. Open PowerShell as administrator and run:  wsl --install" >&2
+    echo "  2. Reboot, open the Ubuntu app, then re-run install.sh inside WSL." >&2
+    echo "" >&2
+    echo "WSL setup: https://learn.microsoft.com/windows/wsl/install" >&2
+    exit 1
+    ;;
+  *)
+    # Unknown OS — let it proceed but warn. We've never tested here, so the
+    # user gets ownership of the outcome.
+    echo "WARN: unrecognized OS '$(uname -s 2>/dev/null)'. install.sh has only been tested on macOS / Linux / WSL — proceed at your own risk." >&2
+    ;;
+esac
+
 # -- Config --------------------------------------------------------------------
 
 REPO="${MAPICK_REPO:-mapick-ai/mapick}"


### PR DESCRIPTION
## Summary

Detect Windows-native shells (Git Bash / Cygwin / MSYS / MINGW) at the very top of \`install.sh\` and exit with a 4-line WSL setup hint instead of crashing partway through with confusing chmod / symlink errors.

Closes #12 (the OS-detect part). Cross-platform marketplace install (Option A in the issue) is **not** addressed here — that's an OpenClaw-side decision.

## Behavior

| \`uname -s\` | Action |
| --- | --- |
| \`Linux*\` / \`Darwin*\` | proceed (POSIX path) |
| \`CYGWIN*\` / \`MSYS*\` / \`MINGW*\` / \`MINGW64_NT*\` / \`MSYS_NT*\` | exit 1 with WSL hint |
| anything else | WARN and proceed (untested, user-owned) |

## Friendly error (Cygwin/MSYS/MINGW path)

```
ERROR: install.sh detected a non-POSIX shell (MINGW64_NT-10.0).

On Windows, install Mapick via WSL (Windows Subsystem for Linux):
  1. Open PowerShell as administrator and run:  wsl --install
  2. Reboot, open the Ubuntu app, then re-run install.sh inside WSL.

WSL setup: https://learn.microsoft.com/windows/wsl/install
```

## Test plan

- [x] \`bash -n install.sh\` clean
- [x] macOS \`uname -s == Darwin\` → no platform-check output, proceeds (failures downstream are pre-existing)
- [x] Stub \`uname\` → \`CYGWIN_NT-10.0\` → exit 1 with hint
- [x] Stub \`uname\` → \`MSYS_NT-10.0\` → exit 1 with hint
- [x] Stub \`uname\` → \`MINGW64_NT-10.0\` → exit 1 with hint
- [x] Stub \`uname\` → \`PlanNineFromOuterSpace\` → WARN + proceed

## Risks

- Adds 27 lines at the top of install.sh; runs before any color codes / curl call, so a missing-uname environment can't escape into the rest of the script.
- The detection branches on bash globs (\`CYGWIN*\` etc.), which work in any POSIX bash 3+. Tested by stubbing \`uname\` rather than executing on actual Windows; willing to add a real CI matrix when we have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)