### PR TITLE
fix(skill): apply AI taste tags to /mapick report brewing branch (follow-up to #45)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -98,8 +98,9 @@ report command directly and render only the final card or final user-facing
 error. Never include phrases like "let me check", "according to SKILL.md", or
 raw tool reasoning.
 
-If `usageDays < 7` or `totalInvocations < 50` → render brewing card, do NOT generate HTML.
-Otherwise generate self-contained HTML per `prompts/persona-production.md`, save only to `/tmp/mapick-report-{id}.html`, then `share <reportId> /tmp/mapick-report-{id}.html <locale>`. Never pass any other local file path to `share`.
+If `usageDays < 7` or `totalInvocations < 50` → render the brewing card (do NOT generate HTML), then **call `node scripts/shell.js summary` and append the AI Taste Tags block** (see §Auto-trigger / First-run → AI Taste Tags). The brewing card alone gives the user nothing to share or talk about; the taste tags from `summary` data give them a day-1 takeaway even when persona is still cooking.
+
+Otherwise (enough usage data) generate self-contained HTML per `prompts/persona-production.md`, save only to `/tmp/mapick-report-{id}.html`, then `share <reportId> /tmp/mapick-report-{id}.html <locale>`. Never pass any other local file path to `share`.
 
 Rate limits: report/share 10/day per fp; HTML > 200KB → 413, regenerate shorter.
 
@@ -370,7 +371,14 @@ If `never_used == 0 && idle_30 == 0`: skip negativity → "Clean setup. Top 10%.
 
 ### AI Taste Tags (generate from summary data, no extra API call)
 
-After rendering the summary card, generate **2–3 taste tags** from the data already returned by `summary`. No extra command, no backend call. Persona report stays brewing — these tags are a separate, lightweight day-1 artifact.
+Generate **2–3 taste tags** from the data already returned by `summary` (`total`, `active`, `never_used`, `idle_30`, `top_used`). These tags are a lightweight day-1 artifact — they replace nothing, they augment.
+
+Two contexts to apply:
+
+1. **First-run summary card** — append after the summary card.
+2. **`/mapick report` brewing branch** (§3) — when persona is still cooking, render the brewing card, then call `summary` (one extra command — that's it; no backend addition) and append these tags so the user has something to react to right away.
+
+Skip the entire taste-tags block when `total == 0` (a fresh install with no skills installed yet — no signal to riff on).
 
 Lookup tables:
 
@@ -415,8 +423,6 @@ End with the share CTA:
 ```
 
 (The `s.mapick.ai` share link will land in V2; today the CTA bounces a friend through the same first-run flow.)
-
-Skip the entire taste-tags block when `total == 0` (a fresh install with no skills installed yet — no signal to riff on).
 
 Full 6-step flow: `reference/flows.md#first-run-summary`.
 


### PR DESCRIPTION
## Symptom

User runs \`/mapick report\` on day 1. Persona is brewing (\`usageDays < 7\` or \`totalInvocations < 50\`), AI renders just:

\`\`\`
🌱 Persona 还在酿造中…
目前使用数据还不够 — daysUsed: 0. ...
\`\`\`

Nothing to share, nothing to react to, nothing to bring a friend in. The whole point of #45 / PR #46 — \"day-1 word-of-mouth driver\" — never reaches users who type \`/mapick report\` first (which is most of them, since the command is named after the artifact they want).

## Why the original PR didn't catch this

PR #46 inserted the taste-tags rendering rule into the **first-run summary card** section only. \`/mapick report\` is a different code path (§3) and never read those rules.

## Fix

Two SKILL.md edits, no code:

1. **§3 Persona Report** — extend the brewing-branch instruction:
   > render the brewing card, **then call \`node scripts/shell.js summary\` and append the AI Taste Tags block.**

2. **§AI Taste Tags** — clarify the rule applies in TWO contexts (first-run summary AND brewing report), not just the original path. Moved the \`total == 0\` skip from a trailing one-liner into the opening rule so it's read as part of the contract.

No new shell command, no backend call (\`summary\` already exists), no shell.js change.

## Acceptance

- [x] User runs \`/mapick report\` on day 1 → AI renders brewing card AS BEFORE, then calls \`summary\`, then appends the 3-tag block + 冷知识 + share CTA.
- [x] User runs first-run init (existing path) → unchanged behavior (still appends taste tags after summary card).
- [x] When \`total == 0\` → no taste tags emitted in either context.
- [x] Persona report mature path (\`usageDays >= 7\` AND \`totalInvocations >= 50\`) → unchanged; still generates HTML + share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)