### PR TITLE
fix: 4 audit follow-ups — diagnose shadow / notify route / dev-build / command drift (closes #51)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -18,6 +18,7 @@ Priority: **recommendation = privacy > persona > safety score > cleanup > everyt
   you are reading SKILL.md, loading reference files, checking handlers, or
   deciding which tool to call. Run the command and render only the final
   user-facing result.
+- **Use the literal command names registered in `scripts/shell.js` HANDLERS — do not abbreviate or invent shorthand.** Right: `privacy consent-decline`, `privacy consent-agree`, `recommend:track`, `clean:track`, `update:check`, `notify:plan`. Wrong: `privacy decline`, `privacy agree`, `recommend track`, `update check`. If a command appears to be missing, surface the error code as-is (`unknown_command`) — do not silently substitute a similar-looking command (e.g. don't fall through to `summary` because `status` "looked wrong").
 
 Detailed rendering, multi-step flows, error templates, and lifecycle rules live in `reference/`. Load on demand.
 
@@ -248,6 +249,8 @@ Returns `{intent: "update:check", items: [...]}`. Each item is one update opport
 
 `settings.update_mode: "off"` returns empty items + an explainer message. Same when `consent_declined`.
 
+`dev_build: true` on the response means the running tree is a local / unreleased build (`local-<sha>-<ts>` etc.). Mapick suppresses `mapick_self` items in that case — say "Running a local dev build (`<installed_version>`); release-channel updates don't apply" and only render any remaining items (`skill` / `notify_missing`).
+
 ### Render `update:check`
 
 If `items: []` and no `message`: reply "Everything's up to date." If `items: []` with `message`: render the message verbatim. Otherwise:
@@ -310,7 +313,12 @@ NEVER auto-confirm. NEVER omit the `what_it_doesnt` line.
    - `kind: "instruction"` → execute the multi-step instruction in `instruction` text. Typically this means: run a list/inspect command, parse its output, then run zero-or-more derived commands. Capture each derived command's outcome.
    - Capture exit code + last 200 chars of stderr per command.
 2. On any failure: stop. If `after_failure_rollback`, run it. Tell user the exact failure (translate stderr).
-3. On full success: run `after_success_track`. Reply with one-line confirmation.
+3. On full success: run `after_success_track`.
+4. **For `notify:plan` only — verify delivery route before claiming success.** After step 3, run `openclaw cron list --json`, find the `mapick-notify` entry, then run `openclaw chat list --json` (or the equivalent on the active OpenClaw runtime) to confirm at least one chat route is registered. If no route exists, the cron will fire but fail-close — surface this to the user explicitly:
+
+   > ⚠️ Cron is scheduled, but no chat delivery route is configured. Set up a route with `openclaw chat add ...` or notifications will silently drop.
+
+   Do NOT report a clean "all set" without this check passing. Otherwise, reply with one-line confirmation.
 
 ### Settings
 
@@ -364,7 +372,7 @@ That's a <activation_rate> activation rate.
 context window. Every conversation, your agent loads them for nothing.
 
 🔒 Outbound: anonymous device id + skill IDs you act on + timestamps.
-   Audit: /mapick privacy log    Decline: /mapick privacy decline
+   Audit: /mapick privacy log    Decline: /mapick privacy consent-decline
 ```
 
 If `never_used == 0 && idle_30 == 0`: skip negativity → "Clean setup. Top 10%." If `total <= 3`: skip the zombie angle → "Just getting started — let me find tools that match your workflow." If `has_backend: false`: skip the heavy-hitters + safety-check sections; say "Backend offline; counts only."

--- a/reference/rendering.md
+++ b/reference/rendering.md
@@ -183,7 +183,7 @@ context window. Every conversation, your agent loads them for nothing.
 Clean them and everything gets faster.
 
 🔒 Outbound: anonymous device id + skill IDs you act on + timestamps.
-   Audit: /mapick privacy log    Decline: /mapick privacy decline
+   Audit: /mapick privacy log    Decline: /mapick privacy consent-decline
 ```
 
 If `never_used == 0 && idle_30 == 0`: skip negativity → "Clean setup. Everything you installed, you actually use. That puts you in the top 10%."

--- a/scripts/lib/doctor.js
+++ b/scripts/lib/doctor.js
@@ -149,15 +149,17 @@ function checkCache() {
 }
 
 function checkShadow() {
+  // Only warn when BOTH a managed install AND a workspace copy exist —
+  // workspace-only is fine, managed-only is fine, both is the silent override.
+  const managedSkill = path.join(
+    os.homedir(), ".openclaw", "skills", "mapick", "SKILL.md",
+  );
   const wsDir = path.join(
-    os.homedir(),
-    ".openclaw",
-    "workspace",
-    "skills",
-    "mapick",
+    os.homedir(), ".openclaw", "workspace", "skills", "mapick",
   );
   const wsSkill = path.join(wsDir, "SKILL.md");
-  if (fs.existsSync(wsSkill)) {
+  const bothExist = fs.existsSync(managedSkill) && fs.existsSync(wsSkill);
+  if (bothExist) {
     return {
       id: "mapick.shadow",
       owner: "[Mapick]",

--- a/scripts/lib/misc.js
+++ b/scripts/lib/misc.js
@@ -41,6 +41,10 @@ async function handleWeekly(_args, ctx) {
 // Single GET /notify/daily-check; backend handles version cmp + zombies + activity bump.
 async function handleNotify() {
   const installedVer = readInstalledVersion() || "";
+  // Local / dev builds are by definition ahead of any tagged release; don't
+  // surface mapick_self version alerts for them — that just nags during dev
+  // validation. Still write last_notify_at + return silence-first {alerts:[]}.
+  const isDevBuild = /^(local|dev)-/.test(installedVer);
   // Backend has a per-repo allowlist; without `repo` it returns alerts: [].
   const params = new URLSearchParams();
   if (installedVer) params.set("currentVersion", installedVer);
@@ -49,18 +53,20 @@ async function handleNotify() {
   params.set("limit", String(OUT_ARR));
   const resp = await httpCall("GET", `/notify/daily-check?${params}`);
   // Silence-first: backend/network failure → empty alerts.
-  if (resp.error) return { intent: "notify", alerts: [] };
+  if (resp.error) return { intent: "notify", alerts: [], dev_build: isDevBuild };
   if (Array.isArray(resp.alerts) && installedVer) {
     const baseVersion = installedVer.split("-")[0];
     resp.alerts = resp.alerts.filter((alert) => {
       if (alert?.type !== "version") return true;
+      // Drop version alerts entirely on dev builds.
+      if (isDevBuild) return false;
       return !(alert.latest && baseVersion === String(alert.latest).split("-")[0]);
     });
   }
   // Track liveness — used by `update:check` to detect stale notify and prompt
   // the user to (re)set up the cron.
   writeConfig("last_notify_at", isoNow());
-  return { intent: "notify", ...resp };
+  return { intent: "notify", dev_build: isDevBuild, ...resp };
 }
 
 async function handleBundle(args, ctx) {
@@ -246,14 +252,21 @@ function handleDiagnose() {
   const version = readInstalledVersion();
 
   const home = process.env.HOME || "";
-  const workspaceDuplicate = path.join(
-    home,
-    ".openclaw",
-    "workspace",
-    "skills",
-    "mapick",
+  // shadow_risk is only real when BOTH a managed install AND a workspace copy
+  // exist — only then does OpenClaw's "workspace beats managed" load order
+  // silently override the managed install. A workspace-only install (the most
+  // common dev path) is fine and shouldn't trip the warning.
+  const managedSkillFile = path.join(
+    home, ".openclaw", "skills", "mapick", "SKILL.md",
   );
-  const duplicateExists = fs.existsSync(path.join(workspaceDuplicate, "SKILL.md"));
+  const workspaceDuplicate = path.join(
+    home, ".openclaw", "workspace", "skills", "mapick",
+  );
+  const workspaceSkillFile = path.join(workspaceDuplicate, "SKILL.md");
+  const managedExists = fs.existsSync(managedSkillFile);
+  const workspaceExists = fs.existsSync(workspaceSkillFile);
+  const shadowRisk = managedExists && workspaceExists;
+
   const skillFile = path.join(CONFIG_DIR, "SKILL.md");
   let skillMtime = null;
   try {
@@ -265,9 +278,9 @@ function handleDiagnose() {
     version,
     loaded_dir: CONFIG_DIR,
     skill_mtime: skillMtime,
-    duplicate_workspace_skill: duplicateExists ? workspaceDuplicate : null,
-    shadow_risk: duplicateExists,
-    fix_hint: duplicateExists
+    duplicate_workspace_skill: shadowRisk ? workspaceDuplicate : null,
+    shadow_risk: shadowRisk,
+    fix_hint: shadowRisk
       ? "Move the workspace copy outside ~/.openclaw/workspace/skills and restart the OpenClaw gateway."
       : null,
   };

--- a/scripts/lib/updates.js
+++ b/scripts/lib/updates.js
@@ -114,7 +114,11 @@ async function handleCheck(_args, ctx) {
 
   // 1. Mapick self version.
   const installedVer = readInstalledVersion();
-  if (installedVer) {
+  // Local / dev builds (`local-<sha>-<ts>` or `dev-*`) are by definition
+  // ahead of any tagged release, so don't surface mapick_self upgrade
+  // prompts for them — that just nags during `latest-code` validation.
+  const isDevBuild = installedVer && /^(local|dev)-/.test(installedVer);
+  if (installedVer && !isDevBuild) {
     const params = new URLSearchParams({
       currentVersion: installedVer,
       repo: "mapick-ai/mapick",
@@ -198,6 +202,8 @@ async function handleCheck(_args, ctx) {
     intent: "update:check",
     checked_at: isoNow(),
     settings: { update_mode: mode },
+    dev_build: isDevBuild || false,
+    installed_version: installedVer || null,
     items,
   };
 }


### PR DESCRIPTION
## Summary

Fixes for 4 of the 5 defects from the 2026-04-30 reset-run audit (\`test/0429/test03/reset-run-20260430/REPORT.md\`). Defect #3 (search-react relevance) is a backend issue, filed separately at mapick-ai/mapick-api#24.

Closes #51.

## Changes

### 1. \`shadow_risk\` false-positive on workspace-only install

A workspace-only install (the most common dev path) was incorrectly reporting \`shadow_risk: true\` and recommending \"delete the workspace copy\" — but there was no managed install to be shadowed.

- \`lib/misc.js handleDiagnose\` — shadow_risk now requires **both** managed AND workspace SKILL.md to exist.
- \`lib/doctor.js checkShadow\` — same logic.

Matches the install.sh post-install reminder logic from #48.

### 2. \`notify:plan\` claimed success while delivery route was fail-closed

The natural-language flow registered a cron job and reported \"daily 10:00 reminders set up\", but \`announce -> last -> no route\` because no chat target was configured. The cron would fire and silently drop.

- \`SKILL.md §10\` step 4 added: after \`after_success_track\`, AI must list the new cron entry, verify a chat route exists, and warn the user if not.

### 3. Local dev builds always shown as outdated

\`local-<sha>-<ts>\` builds were lexically sorted below \`v0.0.15\` and surfaced as upgrade targets via \`update:check\` and \`notify\`.

- \`lib/updates.js handleCheck\` — detect \`/^(local|dev)-/\` prefix; suppress \`mapick_self\` item; response now carries \`dev_build: true\` + \`installed_version\`.
- \`lib/misc.js handleNotify\` — drop version alerts on dev builds; return \`dev_build\` flag.
- \`SKILL.md §10 Render \\\`update:check\\\`\` — documents the dev_build branch (\"Running a local dev build; release-channel updates don't apply\").

### 4. Command-name drift

AI prose used informal command names (\`/mapick privacy decline\` instead of \`consent-decline\`; \`status\` silently \"retrying as summary\").

- \`SKILL.md Global rules\` — new STRICT rule: use literal \`HANDLERS\` keys, never abbreviate, never silently fall through to a similar command.
- \`SKILL.md\` summary card + \`reference/rendering.md\` — \`/mapick privacy decline\` → \`/mapick privacy consent-decline\`.

## Test plan

- [x] workspace-only install → \`diagnose.shadow_risk: false\` ✓
- [x] managed-only install → \`diagnose.shadow_risk: false\` ✓
- [x] both exist → \`diagnose.shadow_risk: true\` ✓
- [x] \`doctor mapick.shadow\` mirrors all 3 cases ✓
- [x] Fake \`.version = local-abc1234-20260430-001122\` → \`update:check\` returns 0 \`mapick_self\` items, \`dev_build: true\`
- [x] same → \`notify\` returns 0 version alerts, \`dev_build: true\`
- [x] grep across SKILL.md + reference/ confirms no \`privacy decline\` shorthand remains
- [ ] Manual: re-run reset-run audit on a clean install → verify all 4 findings clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)