### PR TITLE
fix(shell): missing handleStatus + cron delivery/cleanup improvements (closes #53, #54, #55)

### DIFF
--- a/scripts/lib/skills.js
+++ b/scripts/lib/skills.js
@@ -201,6 +201,13 @@ async function handleInit(_args, ctx) {
   };
 }
 
+async function handleStatus(_args, ctx) {
+  const skills = scanSkills();
+  const fresh = readConfig();
+  fresh.device_fp = fresh.device_fp || ctx.fp;
+  return aggregateSummary(skills, fresh);
+}
+
 function handleScan() {
   return { intent: "scan", skills: scanSkills(), scanned_at: isoNow() };
 }
@@ -219,6 +226,7 @@ module.exports = {
   registerNotifyCron,
   aggregateSummary,
   handleInit,
+  handleStatus,
   handleScan,
   handleSummary,
 };

--- a/scripts/lib/updates.js
+++ b/scripts/lib/updates.js
@@ -216,9 +216,9 @@ async function handleCheck(_args, ctx) {
 const RM_BY_ID_INSTRUCTION = {
   kind: "instruction",
   instruction:
-    "Run `openclaw cron list --json`. Parse the JSON. For EACH entry whose `name` is `mapick-notify`, run `openclaw cron rm <id>` (using the entry's `id` field). This MUST be by ID — `openclaw cron rm mapick-notify` (by name) silently no-ops. If there are no matching entries, do nothing and continue.",
+    "Run `openclaw cron list --json`. Parse the JSON. For EACH entry whose `name` starts with `mapick-notify` or equals `mapick-daily-notify`, run `openclaw cron rm <id>` (using the entry's `id` field). This MUST be by ID — `openclaw cron rm mapick-notify` (by name) silently no-ops. If there are no matching entries, do nothing and continue.",
   rationale:
-    "Idempotent: removes any pre-existing mapick-notify entries before adding a fresh one, so re-running the plan does not accumulate duplicates.",
+    "Idempotent: removes any pre-existing mapick cron entries (both `mapick-notify` and legacy `mapick-daily-notify`) before adding a fresh one, so re-running the plan does not accumulate duplicates.",
 };
 
 // `notify:plan` — return the cron-registration plan for AI to execute.
@@ -246,6 +246,8 @@ function handleNotifyPlan() {
       "Run `node scripts/shell.js notify:disable` to get the by-id removal plan.",
     after_success_track: "node scripts/shell.js notify:track setup_complete",
     after_failure_rollback: null,
+    delivery:
+      "IMPORTANT: cron delivery requires a configured channel (Telegram, Slack, etc.). In local-only setups without a channel, the cron will execute but notifications cannot reach you. The --best-effort-deliver flag ensures the cron does not block on delivery failures, but you need at least one active channel for notifications to be received. Verify with `openclaw cron list --json` after setup — look for deliveryPreviews with a valid route.",
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes three bugs found during the 2026-04-30 comprehensive browser test of Mapick v0.0.15.

### Fix #53: status command returns unknown_command
- `skills.js`: Added `handleStatus` function (was referenced in `shell.js` HANDLERS but never defined/exported)
- The function scans skills, reads config, and returns an aggregate summary

### Fix #54: cron timeout (30019ms > 30s limit)
- `updates.js`: Extended `RM_BY_ID_INSTRUCTION` to also match legacy `mapick-daily-notify` cron entries
- The old NL-created cron had a verbose 30s payload that timed out; re-running notify:plan now properly cleans it up and creates a lean 120s cron

### Fix #55: cron delivery fail-closed (no Telegram route)
- `updates.js`: Added `delivery` field to `notify:plan` output with explicit warning that cron notifications require a configured channel
- Users in local-only setups will now see this warning before setting up the cron

## Test Plan
1. Run `node scripts/shell.js status` — should return summary JSON (was `unknown_command` before)
2. Run `node scripts/shell.js notify:plan` — should include `delivery` warning field
3. Full test report: `test/0430/test01/REPORT.md`

## Before/After
| Command | Before | After |
|---------|--------|-------|
| `shell.js status` | `unknown_command` error | Summary JSON with skills, zombies, activation rate |
| `shell.js notify:plan` | No delivery warning | Includes `delivery` field about channel requirement |
| RM cron cleanup | Only matched `mapick-notify` | Also matches legacy `mapick-daily-notify` |